### PR TITLE
data-sync: Adding data sync config files and validator

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,30 @@
+# Data sync JSON configuration files
+
+The [JSON files](data_sync_list) specify the files and directories to be
+synchronized between the BMCs. Each configuration file must follow the schema
+defined in the [`config/schema/schema.json`](schema/schema.json).
+
+## Adding Files/Directories to Sync
+
+Users can either add files or directories for synchronization to one of the
+existing JSON files, if they fit in the categories described below, or create a
+new JSON file by following the schema in
+[`config/schema/schema.json`](schema/schema.json).
+
+Currently 3 JSON config files are defined under
+[`config/data_sync_list`](data_sync_list) as below.
+
+1. common.json - Contains files and directories of applications whic run across
+   all OpenBMC vendors.
+2. open-power.json - Contains files and directories of Open-Power applications.
+3. ibm.json - Contains files and directories specific to applications on IBM
+   systems.
+
+### Add a new config JSON file
+
+- If another vendor wants to add a new config JSON file into
+  [`config/data_sync_list`](data_sync_list) with their list of data to be
+  synced, define the schema compliant JSON file as `<vendor_name>.json`.
+- Update the `choices` field of `data_sync_list` option in
+  [meson.options](../meson.options) with the JSON file name without .json file
+  extension.

--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -1,0 +1,10 @@
+{
+    "Directories": [
+        {
+            "Path": "/var/lib/phosphor-state-manager/host{}-PersistData",
+            "Description": "Host State Persisted data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
+        }
+    ]
+}

--- a/config/data_sync_list/ibm.json
+++ b/config/data_sync_list/ibm.json
@@ -1,0 +1,10 @@
+{
+    "Files": [
+        {
+            "Path": "/var/lib/ibm/bmcweb/RootCert",
+            "Description": "Root certificate",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
+        }
+    ]
+}

--- a/config/data_sync_list/open-power.json
+++ b/config/data_sync_list/open-power.json
@@ -1,0 +1,10 @@
+{
+    "Files": [
+        {
+            "Path": "/var/lib/phosphor-software-manager/hostfw/running/GUARD",
+            "Description": "GUARD",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
+        }
+    ]
+}

--- a/config/schema/example.json
+++ b/config/schema/example.json
@@ -1,0 +1,40 @@
+{
+    "Files": [
+        {
+            "Path": "/file1/path/to/sync",
+            "Description": "Add details about the data and purpose of the synchronization",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate",
+            "RetryAttempts": 1,
+            "RetryInterval": "PT10S"
+        },
+        {
+            "Path": "/file2/path/to/sync",
+            "Description": "Add details about the data and purpose of the synchronization",
+            "SyncDirection": "Bidirectional",
+            "SyncType": "Periodic",
+            "Periodicity": "PT10S",
+            "RetryAttempts": 2,
+            "RetryInterval": "PT10M"
+        }
+    ],
+    "Directories": [
+        {
+            "Path": "/directory1/path/to/sync",
+            "Description": "Add details about the data and purpose of the synchronization",
+            "SyncDirection": "Passive2Active",
+            "SyncType": "Periodic",
+            "Periodicity": "PT1H",
+            "RetryAttempts": 1,
+            "RetryInterval": "PT10M",
+            "ExcludeFilesList": ["/Path/of/files/must/be/ignored/for/sync"],
+            "IncludeFilesList": ["/Path/of/files/must/be/considered/for/sync"]
+        },
+        {
+            "Path": "/directory2/path/to/sync",
+            "Description": "Add details about the data and purpose of the synchronization",
+            "SyncDirection": "Bidirectional",
+            "SyncType": "Immediate"
+        }
+    ]
+}

--- a/config/schema/schema.json
+++ b/config/schema/schema.json
@@ -1,0 +1,187 @@
+{
+    "title": "Schema for the data sync JSON config files",
+    "$id": "https://github.com/ibm-openbmc/phosphor-data-sync/config/schema/schema.json",
+    "description": "The list of files and directories which need to be synced between BMCs",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "Files": {
+            "description": "List of the files to be synced and details of the mode of sync",
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/files"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "Directories": {
+            "description": "List of the directories to be synced and details of the  mode of sync",
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/directories"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "anyOf": [
+        {
+            "required": ["Files"]
+        },
+        {
+            "required": ["Directories"]
+        }
+    ],
+    "additionalProperties": false,
+
+    "$defs": {
+        "files": {
+            "type": "object",
+            "properties": {
+                "Path": {
+                    "$ref": "#/$defs/path"
+                },
+                "Description": {
+                    "$ref": "#/$defs/description"
+                },
+                "SyncDirection": {
+                    "$ref": "#/$defs/syncDirection"
+                },
+                "SyncType": {
+                    "$ref": "#/$defs/syncType"
+                },
+                "Periodicity": {
+                    "$ref": "#/$defs/periodicity"
+                },
+                "RetryAttempts": {
+                    "$ref": "#/$defs/retryAttempts"
+                },
+                "RetryInterval": {
+                    "$ref": "#/$defs/retryInterval"
+                }
+            },
+            "required": ["Path", "Description", "SyncDirection", "SyncType"],
+            "additionalProperties": false,
+            "allOf": [
+                { "$ref": "#/$defs/conditionForPeriodicity" },
+                { "$ref": "#/$defs/conditionForRetry" }
+            ]
+        },
+
+        "directories": {
+            "type": "object",
+            "properties": {
+                "Path": {
+                    "$ref": "#/$defs/path"
+                },
+                "Description": {
+                    "$ref": "#/$defs/description"
+                },
+                "SyncDirection": {
+                    "$ref": "#/$defs/syncDirection"
+                },
+                "SyncType": {
+                    "$ref": "#/$defs/syncType"
+                },
+                "Periodicity": {
+                    "$ref": "#/$defs/periodicity"
+                },
+                "RetryAttempts": {
+                    "$ref": "#/$defs/retryAttempts"
+                },
+                "RetryInterval": {
+                    "$ref": "#/$defs/retryInterval"
+                },
+                "ExcludeFilesList": {
+                    "$ref": "#/$defs/excludeFilesList"
+                },
+                "IncludeFilesList": {
+                    "$ref": "#/$defs/includeFilesList"
+                }
+            },
+            "required": ["Path", "Description", "SyncDirection", "SyncType"],
+            "additionalProperties": false,
+            "allOf": [
+                { "$ref": "#/$defs/conditionForPeriodicity" },
+                { "$ref": "#/$defs/conditionForRetry" }
+            ]
+        },
+        "path": {
+            "description": "Absolute path of the file/directory to be synced",
+            "$ref": "#/$defs/rootFilePath"
+        },
+        "description": {
+            "description": "A short description about the file/directory to be synced",
+            "type": "string"
+        },
+        "syncDirection": {
+            "description": "The direction in which sync operation need to be performed.",
+            "enum": ["Active2Passive", "Passive2Active", "Bidirectional"]
+        },
+        "syncType": {
+            "description": "The type of sync to be performed",
+            "enum": ["Periodic", "Immediate"]
+        },
+        "retryAttempts": {
+            "description": "The number of retries for the specific file. The value zero indicates no retries. This will override the default value",
+            "type": "integer",
+            "minimum": 0
+        },
+        "retryInterval": {
+            "description": "The time interval in ISO 8601 duration format to perform the retry of sync operation.Eg: PT1M10S - 1 Minute and 10 seconds. This will override the default value",
+            "type": "string",
+            "format": "duration"
+        },
+        "periodicity": {
+            "description": "The time interval in ISO 8601 duration format to perform the periodic sync operation.Eg: PT1M10S - 1 Minute and 10 seconds",
+            "type": "string",
+            "format": "duration"
+        },
+        "excludeFilesList": {
+            "description": "The list of files in the directory that should be excluded while sync operation",
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/rootFilePath"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "includeFilesList": {
+            "description": "The list of files in the directory that should be synced.Rest of the files will be excluded",
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/rootFilePath"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "rootFilePath": {
+            "description": "The value must be a valid UNIX standard root filepath",
+            "type": "string",
+            "pattern": "^/"
+        },
+        "conditionForPeriodicity": {
+            "if": {
+                "type": "object",
+                "properties": { "SyncType": { "const": "Periodic" } },
+                "required": ["SyncType"]
+            },
+            "then": {
+                "properties": {
+                    "Periodicity": { "$ref": "#/$defs/periodicity" }
+                },
+                "required": ["Periodicity"]
+            },
+            "else": { "not": { "required": ["Periodicity"] } }
+        },
+        "conditionForRetry": {
+            "if": {
+                "type": "object",
+                "properties": { "RetryAttempts": { "type": "integer" } },
+                "required": ["RetryAttempts"]
+            },
+            "then": { "required": ["RetryInterval"] },
+            "else": { "not": { "required": ["RetryInterval"] } }
+        }
+    }
+}

--- a/meson.build
+++ b/meson.build
@@ -11,4 +11,39 @@ project('rbmc_data_sync', 'cpp', 'c',
   version: '1.0.0',
   )
 
+data_sync_config_dir = get_option('datadir') + '/phosphor-data-sync/config/data_sync_list/'
+
+
+foreach json_file_name : get_option('data_sync_list')
+
+    #check whether the json file given in the list exist and if so, install the same
+    json_file = files('config/data_sync_list/' + json_file_name + '.json')
+
+    install_data(
+        json_file,
+        install_dir : data_sync_config_dir
+    )
+
+endforeach
+
+# auto generate a config file with required build time configurations
+conf_data = configuration_data()
+
+# TODO : Modify the meson cross compilation setup to override $prefix as '/usr'
+# and use $prefix instead of hardcoding '/usr'.
+conf_data.set_quoted('DATA_SYNC_CONFIG_DIR',
+                '/usr/' + data_sync_config_dir,
+                description : 'Path where the JSON config files resides')
+conf_data.set('DEFAULT_RETRY_ATTEMPTS',
+                get_option('retry_attempts'),
+                description : 'Default retry attempts for all data to be synced')
+conf_data.set('DEFAULT_RETRY_INTERVAL',
+                get_option('retry_interval'),
+                description : 'Default retry interval for all data to be synced')
+
+configure_file(
+    output : 'config.h',
+    configuration : conf_data
+)
+
 subdir('src')

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# The filenames to be installed and considered while sync operation need
+# to be passed as 'data_sync_list' option's value.
+# By default only common.json will get installed
+option(
+    'data_sync_list',
+    type : 'array',
+    choices : ['common','open-power','ibm'],
+    value : ['common'],
+    description : 'The set of files and directories to be synced within BMCs'
+)
+
+# The retry attempt which is applicable for all files/directories in case of sync
+# failure unless overridden from respective JSON file configuration.
+# Default value will be 3.
+# A retry attempt value of zero indicates no retries will be performed.
+option(
+    'retry_attempts',
+    type : 'integer',
+    min : 0,
+    value : 3
+)
+
+# The retry interval in seconds which is applicable for all files/directories
+# during sync retry unless overridden from respective JSON file configuration.
+# Default value is 5secs.
+option(
+    'retry_interval',
+    type : 'integer',
+    value : 5
+)

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+
+/usr/bin/python3 scripts/validate_data_sync_list.py \
+    -s config/schema/schema.json \
+    -f config/data_sync_list/*

--- a/scripts/validate_data_sync_list.py
+++ b/scripts/validate_data_sync_list.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import sys
+
+import jsonschema
+
+r"""
+The script validate JSON files which lists the files and directories to be
+synced between the active and passive BMC against the defined schema by using
+jsonschema module.
+
+"""
+
+
+def validate_schema(data_sync_list, schema_file):
+    """API to validate the JSON config files against schema.json
+
+    Args:
+        data_sync_list : List of JSON config files
+        schema_file : Path of schema file
+
+    Returns: None
+    """
+
+    try:
+        with open(schema_file) as schema_handle:
+            schema_json = json.load(schema_handle)
+
+        for config_file in data_sync_list:
+            try:
+                with open(config_file) as config_file_handle:
+                    config_file_json = json.load(config_file_handle)
+                    jsonschema.validators.validate(
+                        config_file_json,
+                        schema_json,
+                        format_checker=jsonschema.Draft202012Validator.FORMAT_CHECKER,
+                    )
+                    print("Schema validation success for " + config_file)
+            except Exception as error:
+                sys.exit(
+                    "Schema validation failed for "
+                    + config_file
+                    + "!!! Error : "
+                    + str(error)
+                )
+    except Exception as error:
+        sys.exit("Error in schema.json : " + str(error))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Data sync json config file validator"
+    )
+
+    parser.add_argument(
+        "-s",
+        "--schema",
+        dest="schema_file",
+        help="The data sync config JSON's schema file",
+        required=True,
+    )
+
+    parser.add_argument(
+        "-f",
+        "--json_files",
+        nargs="+",
+        dest="data_sync_list",
+        help="The data sync JSON config files",
+        required=True,
+    )
+
+    args = parser.parse_args()
+
+    validate_schema(args.data_sync_list, args.schema_file)


### PR DESCRIPTION
The changes include :-
    - Defines three JSON configuration files (common.json, open-power.json, and ibm.json) under config/data_sync_list.These files allow users to specify the files or directories to be synchronized between BMCs.

    - Creates a schema file (config/schema/schema.json) for the above JSON configuration files, adhering to the Draft 2020-12 schema specification.

    - Adds a Python script (scripts/validate_data_sync_list.py) to validate the JSON config files against the schema, along with another script (scripts/run-ci.sh) that triggers the validator during CI.

    - Adds a new Meson build option (data_sync_list) where users can provide the list of JSON configuration files without .json file extension.

    - Updates the Meson build system to install the specified JSON configuration files in the target directory and generate a config.h file containing all necessary build-time configurations.

Change-Id: I585880e27f87d9a0f9b557d4dfee2d18305e23ab