### PR TITLE
DataSync: Config: Added DestinationPath to configuration

### DIFF
--- a/config/schema/example.json
+++ b/config/schema/example.json
@@ -10,6 +10,7 @@
         },
         {
             "Path": "/file2/path/to/sync",
+            "DestinationPath": "/file2/path/to/target/destination",
             "Description": "Add details about the data and purpose of the synchronization",
             "SyncDirection": "Bidirectional",
             "SyncType": "Periodic",

--- a/config/schema/schema.json
+++ b/config/schema/schema.json
@@ -41,6 +41,9 @@
                 "Path": {
                     "$ref": "#/$defs/path"
                 },
+                "DestinationPath": {
+                    "$ref": "#/$defs/destinationPath"
+                },
                 "Description": {
                     "$ref": "#/$defs/description"
                 },
@@ -73,6 +76,9 @@
             "properties": {
                 "Path": {
                     "$ref": "#/$defs/path"
+                },
+                "DestinationPath": {
+                    "$ref": "#/$defs/destinationPath"
                 },
                 "Description": {
                     "$ref": "#/$defs/description"
@@ -108,6 +114,10 @@
         },
         "path": {
             "description": "Absolute path of the file/directory to be synced",
+            "$ref": "#/$defs/rootFilePath"
+        },
+        "destinationPath": {
+            "description": "Absolute path to the destination file/directory to be synced",
             "$ref": "#/$defs/rootFilePath"
         },
         "description": {

--- a/src/data_sync_config.cpp
+++ b/src/data_sync_config.cpp
@@ -31,6 +31,15 @@ DataSyncConfig::DataSyncConfig(const nlohmann::json& config) :
                   .value_or(SyncType::Immediate))
 {
     // Initiailze optional members
+    if (config.contains("DestinationPath"))
+    {
+        _destPath = config["DestinationPath"].get<std::string>();
+    }
+    else
+    {
+        _destPath = std::nullopt;
+    }
+
     if (_syncType == SyncType::Periodic)
     {
         constexpr auto defPeriodicity = 60;
@@ -80,6 +89,7 @@ bool DataSyncConfig::operator==(const DataSyncConfig& dataSyncCfg) const
 {
     return _path == dataSyncCfg._path &&
            _syncDirection == dataSyncCfg._syncDirection &&
+           _destPath == dataSyncCfg._destPath &&
            _syncType == dataSyncCfg._syncType &&
            _periodicityInSec == dataSyncCfg._periodicityInSec &&
            _retry == dataSyncCfg._retry &&

--- a/src/data_sync_config.hpp
+++ b/src/data_sync_config.hpp
@@ -133,6 +133,11 @@ struct DataSyncConfig
     std::string _path;
 
     /**
+     * @brief The file or directory path to the destination to be synchronized.
+     */
+    std::optional<std::string> _destPath;
+
+    /**
      * @brief Used to get sync direction.
      */
     SyncDirection _syncDirection;

--- a/test/data_sync_config_test.cpp
+++ b/test/data_sync_config_test.cpp
@@ -34,6 +34,7 @@ TEST(DataSyncConfigParserTest, TestImmediateFileSyncWithNoRetry)
     data_sync::config::DataSyncConfig dataSyncConfig(configJSON);
 
     EXPECT_EQ(dataSyncConfig._path, "/file/path/to/sync");
+    EXPECT_EQ(dataSyncConfig._destPath, std::nullopt);
     EXPECT_EQ(dataSyncConfig._syncDirection,
               data_sync::config::SyncDirection::Active2Passive);
     EXPECT_EQ(dataSyncConfig._syncType, data_sync::config::SyncType::Immediate);
@@ -66,6 +67,7 @@ TEST(DataSyncConfigParserTest, TestPeriodicFileSyncWithRetry)
     data_sync::config::DataSyncConfig dataSyncConfig(configJSON);
 
     EXPECT_EQ(dataSyncConfig._path, "/file/path/to/sync");
+    EXPECT_EQ(dataSyncConfig._destPath, std::nullopt);
     EXPECT_EQ(dataSyncConfig._syncDirection,
               data_sync::config::SyncDirection::Passive2Active);
     EXPECT_EQ(dataSyncConfig._syncType, data_sync::config::SyncType::Periodic);
@@ -97,6 +99,7 @@ TEST(DataSyncConfigParserTest, TestImmediateDirectorySyncWithNoRetry)
     data_sync::config::DataSyncConfig dataSyncConfig(configJSON);
 
     EXPECT_EQ(dataSyncConfig._path, "/directory/path/to/sync");
+    EXPECT_EQ(dataSyncConfig._destPath, std::nullopt);
     EXPECT_EQ(dataSyncConfig._syncDirection,
               data_sync::config::SyncDirection::Passive2Active);
     EXPECT_EQ(dataSyncConfig._syncType, data_sync::config::SyncType::Immediate);
@@ -127,6 +130,7 @@ TEST(DataSyncConfigParserTest, TestImmediateAndBidirectionalDirectorySync)
     data_sync::config::DataSyncConfig dataSyncConfig(configJSON);
 
     EXPECT_EQ(dataSyncConfig._path, "/directory/path/to/sync");
+    EXPECT_EQ(dataSyncConfig._destPath, std::nullopt);
     EXPECT_EQ(dataSyncConfig._syncDirection,
               data_sync::config::SyncDirection::Bidirectional);
     EXPECT_EQ(dataSyncConfig._syncType, data_sync::config::SyncType::Immediate);
@@ -160,6 +164,7 @@ TEST(DataSyncConfigParserTest, TestFileSyncWithInvalidPeriodicity)
     data_sync::config::DataSyncConfig dataSyncConfig(configJSON);
 
     EXPECT_EQ(dataSyncConfig._path, "/file/path/to/sync");
+    EXPECT_EQ(dataSyncConfig._destPath, std::nullopt);
     EXPECT_EQ(dataSyncConfig._syncDirection,
               data_sync::config::SyncDirection::Active2Passive);
     EXPECT_EQ(dataSyncConfig._syncType, data_sync::config::SyncType::Periodic);
@@ -195,6 +200,7 @@ TEST(DataSyncConfigParserTest, TestFileSyncWithInvalidRetryInterval)
     data_sync::config::DataSyncConfig dataSyncConfig(configJSON);
 
     EXPECT_EQ(dataSyncConfig._path, "/file/path/to/sync");
+    EXPECT_EQ(dataSyncConfig._destPath, std::nullopt);
     EXPECT_EQ(dataSyncConfig._syncDirection,
               data_sync::config::SyncDirection::Active2Passive);
     EXPECT_EQ(dataSyncConfig._syncType, data_sync::config::SyncType::Periodic);
@@ -227,6 +233,7 @@ TEST(DataSyncConfigParserTest, TestFileSyncWithInvalidSyncDirection)
     data_sync::config::DataSyncConfig dataSyncConfig(configJSON);
 
     EXPECT_EQ(dataSyncConfig._path, "/file/path/to/sync");
+    EXPECT_EQ(dataSyncConfig._destPath, std::nullopt);
     EXPECT_EQ(dataSyncConfig._syncDirection,
               data_sync::config::SyncDirection::Active2Passive);
     EXPECT_EQ(dataSyncConfig._syncType, data_sync::config::SyncType::Immediate);
@@ -257,6 +264,39 @@ TEST(DataSyncConfigParserTest, TestFileSyncWithInvalidSyncType)
     data_sync::config::DataSyncConfig dataSyncConfig(configJSON);
 
     EXPECT_EQ(dataSyncConfig._path, "/file/path/to/sync");
+    EXPECT_EQ(dataSyncConfig._destPath, std::nullopt);
+    EXPECT_EQ(dataSyncConfig._syncDirection,
+              data_sync::config::SyncDirection::Active2Passive);
+    EXPECT_EQ(dataSyncConfig._syncType, data_sync::config::SyncType::Immediate);
+    EXPECT_EQ(dataSyncConfig._periodicityInSec, std::nullopt);
+    EXPECT_EQ(dataSyncConfig._retry, std::nullopt);
+    EXPECT_EQ(dataSyncConfig._excludeFileList, std::nullopt);
+    EXPECT_EQ(dataSyncConfig._includeFileList, std::nullopt);
+}
+
+/*
+ * Test when the input JSON contains the details of the file to be synced
+ * immediately with valid Destination and no overriding retry attempt and
+ * retry interval.
+ */
+TEST(DataSyncConfigParserTest, TestFileSyncWithValidDestination)
+{
+    // JSON object with details of file to be synced.
+    const auto configJSON = R"(
+        {
+            "Path": "/file/path/to/sync",
+            "DestinationPath": "/file/path/to/destination",
+            "Description": "Add details about the data and purpose of the synchronization",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
+        }
+
+    )"_json;
+
+    data_sync::config::DataSyncConfig dataSyncConfig(configJSON);
+
+    EXPECT_EQ(dataSyncConfig._path, "/file/path/to/sync");
+    EXPECT_EQ(dataSyncConfig._destPath, "/file/path/to/destination");
     EXPECT_EQ(dataSyncConfig._syncDirection,
               data_sync::config::SyncDirection::Active2Passive);
     EXPECT_EQ(dataSyncConfig._syncType, data_sync::config::SyncType::Immediate);


### PR DESCRIPTION
  - This optional property stores absolute path to target file/directory where files should be synced.
  - This will enable syncing of files to a location different than the source, offering greater flexibility in file sync.

Tested:

    - Verified the new JSON configuration

Change-Id: I5639126250ff12d6175045cebd1be9c19aceed5a
Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>