### PR TITLE
Manager: Added API to sync data in UT environment

### DIFF
--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -79,6 +79,16 @@ class Manager
     sdbusplus::async::task<> startSyncEvents();
 
     /**
+     * @brief A helper rsync wrapper API that syncs data to sibling
+     *        BMC, with different behavior in the unit test environment,
+     *        performing a local copy instead.
+     *
+     * @param[in] dataSyncCfg - The data sync config to sync
+     *
+     */
+    static void syncData(const config::DataSyncConfig& dataSyncCfg);
+
+    /**
      * @brief A helper to API to monitor data to sync if its changed
      *
      * @param[in] dataSyncCfg - The data sync config to sync

--- a/test/meson.build
+++ b/test/meson.build
@@ -37,6 +37,7 @@ foreach test_file : test_source_files
                 rbmc_data_sync_dependencies,
             ],
             include_directories: inc_dir,
+            cpp_args : ['-DUNIT_TEST'],
         )
     )
 endforeach


### PR DESCRIPTION
- Adding this API to help with future sync code testing.
- The added API uses rsync under the hood to perform a local copy for unit test verification, remote copy support will be added in a future commit.
- For testing we would require the data to be synced in same system. To enable it to have a compiler flag which would be used by test code.

Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>