### PR TITLE
ExternalData: Fetch required additional dependent data's

### DIFF
--- a/src/external_data_ifaces.cpp
+++ b/src/external_data_ifaces.cpp
@@ -9,7 +9,8 @@ namespace data_sync::ext_data
 sdbusplus::async::task<> ExternalDataIFaces::startExtDataFetches()
 {
     // NOLINTNEXTLINE
-    co_return co_await fetchBMCRedundancyMgrProps();
+    co_return co_await sdbusplus::async::execution::when_all(
+        fetchBMCRedundancyMgrProps(), fetchSiblingBmcIP());
 }
 
 BMCRole ExternalDataIFaces::bmcRole() const
@@ -30,6 +31,16 @@ BMCRedundancy ExternalDataIFaces::bmcRedundancy() const
 void ExternalDataIFaces::bmcRedundancy(const BMCRedundancy& bmcRedundancy)
 {
     _bmcRedundancy = bmcRedundancy;
+}
+
+SiblingBmcIP ExternalDataIFaces::siblingBmcIP() const
+{
+    return _siblingBmcIP;
+}
+
+void ExternalDataIFaces::siblingBmcIP(const SiblingBmcIP& siblingBmcIP)
+{
+    _siblingBmcIP = siblingBmcIP;
 }
 
 } // namespace data_sync::ext_data

--- a/src/external_data_ifaces.cpp
+++ b/src/external_data_ifaces.cpp
@@ -10,7 +10,8 @@ sdbusplus::async::task<> ExternalDataIFaces::startExtDataFetches()
 {
     // NOLINTNEXTLINE
     co_return co_await sdbusplus::async::execution::when_all(
-        fetchBMCRedundancyMgrProps(), fetchSiblingBmcIP());
+        fetchBMCRedundancyMgrProps(), fetchSiblingBmcIP(),
+        fetchRbmcCredentials());
 }
 
 BMCRole ExternalDataIFaces::bmcRole() const
@@ -33,7 +34,7 @@ void ExternalDataIFaces::bmcRedundancy(const BMCRedundancy& bmcRedundancy)
     _bmcRedundancy = bmcRedundancy;
 }
 
-SiblingBmcIP ExternalDataIFaces::siblingBmcIP() const
+const SiblingBmcIP& ExternalDataIFaces::siblingBmcIP() const
 {
     return _siblingBmcIP;
 }
@@ -43,4 +44,13 @@ void ExternalDataIFaces::siblingBmcIP(const SiblingBmcIP& siblingBmcIP)
     _siblingBmcIP = siblingBmcIP;
 }
 
+void ExternalDataIFaces::rbmcCredentials(const RbmcCredentials& rbmcCredentials)
+{
+    _rbmcCredentials = rbmcCredentials;
+}
+
+const RbmcCredentials& ExternalDataIFaces::rbmcCredentials() const
+{
+    return _rbmcCredentials;
+}
 } // namespace data_sync::ext_data

--- a/src/external_data_ifaces.hpp
+++ b/src/external_data_ifaces.hpp
@@ -12,6 +12,9 @@ using RBMC = sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
 using BMCRole = RBMC::Role;
 using BMCRedundancy = bool;
 using SiblingBmcIP = std::string;
+using RbmcUserName = std::string;
+using RbmcPassword = std::string;
+using RbmcCredentials = std::pair<RbmcUserName, RbmcPassword>;
 
 /**
  * @class ExternalDataIFaces
@@ -59,7 +62,14 @@ class ExternalDataIFaces
      *
      * @return The Sibling BMC IP
      */
-    SiblingBmcIP siblingBmcIP() const;
+    const SiblingBmcIP& siblingBmcIP() const;
+
+    /**
+     * @brief Used to obtain the BMC username and password
+     *
+     * @return BMC Username and Password
+     */
+    const RbmcCredentials& rbmcCredentials() const;
 
   protected:
     /**
@@ -71,6 +81,11 @@ class ExternalDataIFaces
      * @brief Used to retrieve the Sibling BMC IP.
      */
     virtual sdbusplus::async::task<> fetchSiblingBmcIP() = 0;
+
+    /**
+     * @brief Used to retrieve the BMC Username and Password.
+     */
+    virtual sdbusplus::async::task<> fetchRbmcCredentials() = 0;
 
     /**
      * @brief A utility API to assign the retrieved BMC role.
@@ -99,6 +114,16 @@ class ExternalDataIFaces
      */
     void siblingBmcIP(const SiblingBmcIP& siblingBmcIP);
 
+    /**
+     * @brief A utility API to assign the retrieved BMC Username and Password.
+     *
+     * @param[in] rbmcCredentials - The retrieved Sibling BMC Username and
+     *                              Password.
+     *
+     * @return None.
+     */
+    void rbmcCredentials(const RbmcCredentials& rbmcCredentials);
+
   private:
     /**
      * @brief Holds the BMC role.
@@ -114,6 +139,11 @@ class ExternalDataIFaces
      * @brief hold the Sibling BMC IP
      */
     SiblingBmcIP _siblingBmcIP;
+
+    /**
+     * @brief This is Pair, hold the BMCs Username and Password
+     */
+    RbmcCredentials _rbmcCredentials;
 };
 
 } // namespace data_sync::ext_data

--- a/src/external_data_ifaces.hpp
+++ b/src/external_data_ifaces.hpp
@@ -11,6 +11,7 @@ namespace data_sync::ext_data
 using RBMC = sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy;
 using BMCRole = RBMC::Role;
 using BMCRedundancy = bool;
+using SiblingBmcIP = std::string;
 
 /**
  * @class ExternalDataIFaces
@@ -53,11 +54,23 @@ class ExternalDataIFaces
      */
     BMCRedundancy bmcRedundancy() const;
 
+    /**
+     * @brief Used to obtain the Sibling BMC IP.
+     *
+     * @return The Sibling BMC IP
+     */
+    SiblingBmcIP siblingBmcIP() const;
+
   protected:
     /**
      * @brief Used to retrieve the BMC role.
      */
     virtual sdbusplus::async::task<> fetchBMCRedundancyMgrProps() = 0;
+
+    /**
+     * @brief Used to retrieve the Sibling BMC IP.
+     */
+    virtual sdbusplus::async::task<> fetchSiblingBmcIP() = 0;
 
     /**
      * @brief A utility API to assign the retrieved BMC role.
@@ -77,6 +90,15 @@ class ExternalDataIFaces
      */
     void bmcRedundancy(const BMCRedundancy& bmcRedundancy);
 
+    /**
+     * @brief A utility API to assign the retrieved Sibling BMC IP.
+     *
+     * @param[in] siblingBmcIP - The retrieved Sibling BMC IP.
+     *
+     * @return None.
+     */
+    void siblingBmcIP(const SiblingBmcIP& siblingBmcIP);
+
   private:
     /**
      * @brief Holds the BMC role.
@@ -87,6 +109,11 @@ class ExternalDataIFaces
      * @brief Indicates whether BMC redundancy is enabled in the system.
      */
     BMCRedundancy _bmcRedundancy{false};
+
+    /**
+     * @brief hold the Sibling BMC IP
+     */
+    SiblingBmcIP _siblingBmcIP;
 };
 
 } // namespace data_sync::ext_data

--- a/src/external_data_ifaces_impl.cpp
+++ b/src/external_data_ifaces_impl.cpp
@@ -60,11 +60,8 @@ sdbusplus::async::task<> ExternalDataIFacesImpl::fetchSiblingBmcIP()
         redundancy::Sibling;
 
     std::string siblingBMCInstancePath =
-        std::string(sdbusplus::common::xyz::openbmc_project::state::bmc::
-                        redundancy::Sibling::namespace_path::value) +
-        "/" +
-        sdbusplus::common::xyz::openbmc_project::state::bmc::redundancy::
-            Sibling::namespace_path::bmc;
+        std::string(SiblingBMC::namespace_path::value) + "/" +
+        SiblingBMC::namespace_path::bmc;
 
     auto siblingBMCMgr = SiblingBMCMgr(_ctx)
                              .service(SiblingBMC::interface)
@@ -79,10 +76,22 @@ sdbusplus::async::task<> ExternalDataIFacesImpl::fetchSiblingBmcIP()
     }
     else
     {
-        // Using the simics bmc0 eth0 IP address
+        // Using the simics bmc1 eth0 IP address
         siblingBmcIP("10.2.2.100");
     }
 
+    co_return;
+}
+
+// NOLINTNEXTLINE
+sdbusplus::async::task<> ExternalDataIFacesImpl::fetchRbmcCredentials()
+{
+    // TODO: Currently, the username and password for BMCs are hardcoded.
+    // Once user management DBus exposes the username and the encrypted password
+    // available, update the logic to retrieve them dynamically.
+
+    // here, username hardcode as service and password as 0penBmc0
+    rbmcCredentials(std::make_pair("service", "0penBmc0"));
     co_return;
 }
 

--- a/src/external_data_ifaces_impl.hpp
+++ b/src/external_data_ifaces_impl.hpp
@@ -44,6 +44,11 @@ class ExternalDataIFacesImpl : public ExternalDataIFaces
     sdbusplus::async::task<> fetchSiblingBmcIP() override;
 
     /**
+     * @brief Used to retrieve the BMC Username and Password.
+     */
+    sdbusplus::async::task<> fetchRbmcCredentials() override;
+
+    /**
      * @brief Used to get the async context
      */
     sdbusplus::async::context& _ctx;

--- a/src/external_data_ifaces_impl.hpp
+++ b/src/external_data_ifaces_impl.hpp
@@ -39,6 +39,11 @@ class ExternalDataIFacesImpl : public ExternalDataIFaces
     sdbusplus::async::task<> fetchBMCRedundancyMgrProps() override;
 
     /**
+     * @brief Used to retrieve the Sibling BMC IP from Dbus.
+     */
+    sdbusplus::async::task<> fetchSiblingBmcIP() override;
+
+    /**
      * @brief Used to get the async context
      */
     sdbusplus::async::context& _ctx;

--- a/test/manager_test.cpp
+++ b/test/manager_test.cpp
@@ -77,6 +77,10 @@ TEST_F(ManagerTest, ParseDataSyncCfg)
         // NOLINTNEXTLINE
         .WillRepeatedly([]() -> sdbusplus::async::task<> { co_return; });
 
+    EXPECT_CALL(*mockExtDataIfaces, fetchSiblingBmcIP())
+        // NOLINTNEXTLINE
+        .WillRepeatedly([]() -> sdbusplus::async::task<> { co_return; });
+
     sdbusplus::async::context ctx;
 
     data_sync::Manager manager{ctx, std::move(extDataIface),

--- a/test/manager_test.cpp
+++ b/test/manager_test.cpp
@@ -81,6 +81,10 @@ TEST_F(ManagerTest, ParseDataSyncCfg)
         // NOLINTNEXTLINE
         .WillRepeatedly([]() -> sdbusplus::async::task<> { co_return; });
 
+    EXPECT_CALL(*mockExtDataIfaces, fetchRbmcCredentials())
+        // NOLINTNEXTLINE
+        .WillRepeatedly([]() -> sdbusplus::async::task<> { co_return; });
+
     sdbusplus::async::context ctx;
 
     data_sync::Manager manager{ctx, std::move(extDataIface),

--- a/test/mock_ext_data_ifaces.hpp
+++ b/test/mock_ext_data_ifaces.hpp
@@ -14,6 +14,7 @@ class MockExternalDataIFaces : public ExternalDataIFaces
 
     MOCK_METHOD(sdbusplus::async::task<>, fetchBMCRedundancyMgrProps, (),
                 (override));
+    MOCK_METHOD(sdbusplus::async::task<>, fetchSiblingBmcIP, (), (override));
 };
 
 } // namespace data_sync::ext_data

--- a/test/mock_ext_data_ifaces.hpp
+++ b/test/mock_ext_data_ifaces.hpp
@@ -15,6 +15,7 @@ class MockExternalDataIFaces : public ExternalDataIFaces
     MOCK_METHOD(sdbusplus::async::task<>, fetchBMCRedundancyMgrProps, (),
                 (override));
     MOCK_METHOD(sdbusplus::async::task<>, fetchSiblingBmcIP, (), (override));
+    MOCK_METHOD(sdbusplus::async::task<>, fetchRbmcCredentials, (), (override));
 };
 
 } // namespace data_sync::ext_data


### PR DESCRIPTION
This PR includes the retrieval of the following external dependencies:

- Sibling BMC IP address
- RBMC credentials