### PR TITLE
Manager: Create periodic events for sync process

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -131,8 +131,6 @@ void Manager::syncData(const config::DataSyncConfig& dataSyncCfg)
 {
     using namespace std::string_literals;
     std::string syncCmd{"rsync --archive --compress"};
-
-    // Add source data path
     syncCmd.append(" "s + dataSyncCfg._path);
 
 #ifdef UNIT_TEST
@@ -160,11 +158,16 @@ sdbusplus::async::task<> Manager::monitorDataToSync(
     co_return;
 }
 
-// NOLINTNEXTLINE
-sdbusplus::async::task<> Manager::monitorTimerToSync(
-    [[maybe_unused]] const config::DataSyncConfig& dataSyncCfg)
+sdbusplus::async::task<>
+    // NOLINTNEXTLINE
+    Manager::monitorTimerToSync(const config::DataSyncConfig& dataSyncCfg)
 {
-    // TODO Create timer events to monitor data for sync
+    while (!_ctx.stop_requested())
+    {
+        co_await sdbusplus::async::sleep_for(
+            _ctx, dataSyncCfg._periodicityInSec.value());
+        syncData(dataSyncCfg);
+    }
     co_return;
 }
 

--- a/test/manager_test.cpp
+++ b/test/manager_test.cpp
@@ -1,66 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-
-#include "manager.hpp"
-#include "mock_ext_data_ifaces.hpp"
-
-#include <sdbusplus/async/context.hpp>
-
-#include <filesystem>
-#include <fstream>
-
-#include <gtest/gtest.h>
-
-class ManagerTest : public ::testing::Test
-{
-  protected:
-    static void SetUpTestSuite()
-    {
-        char tmpdir[] = "/tmp/pdsCfgDirXXXXXX";
-        dataSyncCfgDir = mkdtemp(tmpdir);
-        std::filesystem::path dataSyncCfgFile{dataSyncCfgDir / "config.json"};
-        std::ofstream cfgFile(dataSyncCfgFile);
-
-        jsonData = R"(
-                {
-                    "Files": [
-                        {
-                            "Path": "/file/path/to/sync",
-                            "Description": "Parse test file",
-                            "SyncDirection": "Active2Passive",
-                            "SyncType": "Immediate"
-                        }
-                    ],
-                    "Directories": [
-                        {
-                            "Path": "/directory/path/to/sync",
-                            "Description": "Parse test directory",
-                            "SyncDirection": "Passive2Active",
-                            "SyncType": "Periodic",
-                            "Periodicity": "PT5M",
-                            "RetryAttempts": 1,
-                            "RetryInterval": "PT10M",
-                            "ExcludeFilesList": ["/directory/file/to/ignore"],
-                            "IncludeFilesList": ["/directory/file/to/consider"]
-                        }
-                    ]
-                }
-            )"_json;
-
-        cfgFile << jsonData;
-    }
-
-    static void TearDownTestSuite()
-    {
-        std::filesystem::remove_all(dataSyncCfgDir);
-        std::filesystem::remove(dataSyncCfgDir);
-    }
-
-    static std::filesystem::path dataSyncCfgDir;
-    static nlohmann::json jsonData;
-};
+#include "manager_test.hpp"
 
 std::filesystem::path ManagerTest::dataSyncCfgDir;
-nlohmann::json ManagerTest::jsonData;
+std::filesystem::path ManagerTest::tmpDataSyncDataDir;
+nlohmann::json ManagerTest::commonJsonData;
 
 TEST_F(ManagerTest, ParseDataSyncCfg)
 {
@@ -91,12 +34,13 @@ TEST_F(ManagerTest, ParseDataSyncCfg)
                                ManagerTest::dataSyncCfgDir};
 
     EXPECT_FALSE(
-        manager.containsDataSyncCfg(ManagerTest::jsonData["Files"][0]));
+        manager.containsDataSyncCfg(ManagerTest::commonJsonData["Files"][0]));
 
     ctx.spawn(
         sdbusplus::async::sleep_for(ctx, 1ns) |
         sdbusplus::async::execution::then([&ctx]() { ctx.request_stop(); }));
     ctx.run();
 
-    EXPECT_TRUE(manager.containsDataSyncCfg(ManagerTest::jsonData["Files"][0]));
+    EXPECT_TRUE(
+        manager.containsDataSyncCfg(ManagerTest::commonJsonData["Files"][0]));
 }

--- a/test/manager_test.hpp
+++ b/test/manager_test.hpp
@@ -1,0 +1,113 @@
+#include "manager.hpp"
+#include "mock_ext_data_ifaces.hpp"
+
+#include <sdbusplus/async/context.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+class ManagerTest : public ::testing::Test
+{
+  protected:
+    static void SetUpTestSuite()
+    {
+        char tmpdir[] = "/tmp/pdsCfgDirXXXXXX";
+        dataSyncCfgDir = mkdtemp(tmpdir);
+        char tmpDataDir[] = "/tmp/pdsDataDirXXXXXX";
+        tmpDataSyncDataDir = mkdtemp(tmpDataDir);
+        commonJsonData = R"(
+                {
+                    "Files": [
+                        {
+                            "Path": "/file/path/to/sync",
+                            "Description": "Parse test file",
+                            "SyncDirection": "Active2Passive",
+                            "SyncType": "Immediate"
+                        }
+                    ],
+                    "Directories": [
+                        {
+                            "Path": "/directory/path/to/sync",
+                            "Description": "Parse test directory",
+                            "SyncDirection": "Passive2Active",
+                            "SyncType": "Periodic",
+                            "Periodicity": "PT1S",
+                            "RetryAttempts": 1,
+                            "RetryInterval": "PT10M",
+                            "ExcludeFilesList": ["/directory/file/to/ignore"],
+                            "IncludeFilesList": ["/directory/file/to/consider"]
+                        }
+                    ]
+                }
+            )"_json;
+        std::filesystem::path dataSyncCommonCfgFile{dataSyncCfgDir /
+                                                    "common_test_config.json"};
+        std::ofstream cfgFile(dataSyncCommonCfgFile);
+        ASSERT_TRUE(cfgFile.is_open())
+            << "Failed to open " << dataSyncCommonCfgFile;
+        cfgFile << commonJsonData;
+        cfgFile.close();
+    }
+
+    // Set up each individual test
+    void SetUp() override
+    {
+        dataSyncCfgFile = dataSyncCfgDir / "testcase_config.json";
+    }
+
+    // Tear down each individual test
+    void TearDown() override
+    {
+        // Remove each item from the directory
+        for (const auto& entry :
+             std::filesystem::directory_iterator(tmpDataSyncDataDir))
+        {
+            std::filesystem::remove_all(entry.path());
+        }
+        std::filesystem::remove(dataSyncCfgFile);
+    }
+
+    void writeConfig(const nlohmann::json& jsonData)
+    {
+        std::ofstream cfgFile(dataSyncCfgFile);
+        ASSERT_TRUE(cfgFile.is_open()) << "Failed to open " << dataSyncCfgFile;
+        cfgFile << jsonData;
+        cfgFile.close();
+    }
+
+    static void writeData(const std::string& fileName, const std::string& data)
+    {
+        std::ofstream out(fileName);
+        ASSERT_TRUE(out.is_open()) << "Failed to open " << fileName;
+        out << data;
+        out.close();
+    }
+
+    static std::string readData(const std::string& fileName)
+    {
+        if (!std::filesystem::exists(fileName))
+        {
+            return "";
+        }
+        std::ifstream iFile(fileName);
+        std::stringstream content;
+        content << iFile.rdbuf();
+        iFile.close();
+        return content.str();
+    }
+
+    static void TearDownTestSuite()
+    {
+        std::filesystem::remove_all(dataSyncCfgDir);
+        std::filesystem::remove(dataSyncCfgDir);
+        std::filesystem::remove_all(tmpDataSyncDataDir);
+        std::filesystem::remove(tmpDataSyncDataDir);
+    }
+
+    static std::filesystem::path dataSyncCfgDir;
+    static nlohmann::json commonJsonData;
+    static std::filesystem::path tmpDataSyncDataDir;
+    std::filesystem::path dataSyncCfgFile;
+};

--- a/test/meson.build
+++ b/test/meson.build
@@ -22,6 +22,7 @@ endif
 test_source_files = [
         'data_sync_config_test',
         'manager_test',
+        'periodic_sync_test',
     ]
 
 foreach test_file : test_source_files

--- a/test/mock_ext_data_ifaces.hpp
+++ b/test/mock_ext_data_ifaces.hpp
@@ -16,6 +16,10 @@ class MockExternalDataIFaces : public ExternalDataIFaces
                 (override));
     MOCK_METHOD(sdbusplus::async::task<>, fetchSiblingBmcIP, (), (override));
     MOCK_METHOD(sdbusplus::async::task<>, fetchRbmcCredentials, (), (override));
+    void setBMCRole(const BMCRole& role)
+    {
+        return bmcRole(role);
+    }
 };
 
 } // namespace data_sync::ext_data


### PR DESCRIPTION
- Creating sync events that will become active in specified time.  It's aimed at optimizing synchronization for files and directories that do not require immediate updates.
- By scheduling sync events at regular intervals, we can better handle frequently updated data where real-time synchronization
  isn't critical, such as audit logs and host console, will help to reduce load.
- Added utility functions to enable easy testing.

Tested:
- Verified the events are syncing data as required with 4 testcases:
  - PeriodicDataSyncTest: Write but stops before sync interval therefore no sync could take place.
  - PeriodicDataSyncDelayFileTest: Create a file after periodic sync is started, syncs new file after interval is passed.
  - PeriodicDataSyncMultiRWTest: Write multi time and check for sync taking place every time.
  - PeriodicDataSyncP2ATest: Checking passive to active sync.
- Verified behavior in simics environment.

Change-Id: I03aefb85f52d0c429bcb2441300fa1981cea5baa
Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>