### PR TITLE
DataSync: Migrate to SyncBmcData interface

### DIFF
--- a/service_files/xyz.openbmc_project.Control.SyncBMCData.service
+++ b/service_files/xyz.openbmc_project.Control.SyncBMCData.service
@@ -7,7 +7,7 @@ After=xyz.openbmc_project.State.BMC.Redundancy.service
 ExecStart=/usr/libexec/phosphor-data-sync/phosphor-rbmc-data-sync-mgr
 Restart=always
 Type=dbus
-BusName=xyz.openbmc_project.DataSync.BMCData
+BusName=xyz.openbmc_project.Control.SyncBMCData
 
 [Install]
 WantedBy=obmc-bmc-active.target

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,7 +35,7 @@ executable('phosphor-rbmc-data-sync-mgr',
 
 systemd_system_unit_dir = dependency('systemd').get_variable(
   pkgconfig: 'systemdsystemunitdir')
-rbmc_data_sync_service_unit = '../service_files/xyz.openbmc_project.DataSync.BMCData.service'
+rbmc_data_sync_service_unit = '../service_files/xyz.openbmc_project.Control.SyncBMCData.service'
 configure_file(
   copy: true,
   input: rbmc_data_sync_service_unit,

--- a/src/rbmc_data_sync_main.cpp
+++ b/src/rbmc_data_sync_main.cpp
@@ -8,15 +8,15 @@
 #include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/async/context.hpp>
 #include <sdbusplus/server/manager.hpp>
-#include <xyz/openbmc_project/DataSync/BMCData/common.hpp>
+#include <xyz/openbmc_project/Control/SyncBMCData/common.hpp>
 
 int main()
 {
-    using BMCDataSync =
-        sdbusplus::common::xyz::openbmc_project::data_sync::BMCData;
+    using SyncBMCData =
+        sdbusplus::common::xyz::openbmc_project::control::SyncBMCData;
 
     sdbusplus::async::context ctx;
-    sdbusplus::server::manager_t objManager{ctx, BMCDataSync::namespace_path};
+    sdbusplus::server::manager_t objManager{ctx, SyncBMCData::instance_path};
 
     data_sync::Manager manager{
         ctx, std::make_unique<data_sync::ext_data::ExternalDataIFacesImpl>(ctx),
@@ -25,7 +25,7 @@ int main()
     // clang-tidy currently mangles this into something unreadable
     // NOLINTNEXTLINE
     ctx.spawn([](sdbusplus::async::context& ctx) -> sdbusplus::async::task<> {
-        ctx.request_name(BMCDataSync::interface);
+        ctx.request_name(SyncBMCData::interface);
         co_return;
     }(ctx));
 


### PR DESCRIPTION
- As per community feedback, the previous BmcData interface is no longer agreed upon, Following the community's recommendation, this update migrates to the new SyncBmcData interface and folder structure

- The migration is aligned with the latest upstream changes, ensuring compatibility with the updated interface in phosphor-dbus-interfaces

- Reference: https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/76289