### PR TITLE
Manager: update syncData API

### DIFF
--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -85,8 +85,11 @@ class Manager
      *
      * @param[in] dataSyncCfg - The data sync config to sync
      *
+     * @return Returns true if sync succeeds; otherwise, returns false
+     *
      */
-    static void syncData(const config::DataSyncConfig& dataSyncCfg);
+    static sdbusplus::async::task<bool>
+        syncData(const config::DataSyncConfig& dataSyncCfg);
 
     /**
      * @brief A helper to API to monitor data to sync if its changed


### PR DESCRIPTION
- The syncData API needed to be updated because during a full sync we spawn a new config each time to handle it asynchronously, The existing implementation wasn’t designed to handle tasks running asynchronously, which is required for full sync operations

- To support this, the return type of syncData was changed to work with asynchronous execution, ensuring that tasks are handled concurrently