### PR TITLE
ManagerTest: Moved the commonJson

### DIFF
--- a/test/manager_test.cpp
+++ b/test/manager_test.cpp
@@ -10,6 +10,40 @@ TEST_F(ManagerTest, ParseDataSyncCfg)
     using namespace std::literals;
     namespace ed = data_sync::ext_data;
 
+    commonJsonData = R"(
+            {
+                "Files": [
+                    {
+                        "Path": "/file/path/to/sync",
+                        "Description": "Parse test file",
+                        "SyncDirection": "Active2Passive",
+                        "SyncType": "Immediate"
+                    }
+                ],
+                "Directories": [
+                    {
+                        "Path": "/directory/path/to/sync",
+                        "Description": "Parse test directory",
+                        "SyncDirection": "Passive2Active",
+                        "SyncType": "Periodic",
+                        "Periodicity": "PT1S",
+                        "RetryAttempts": 1,
+                        "RetryInterval": "PT10M",
+                        "ExcludeFilesList": ["/directory/file/to/ignore"],
+                        "IncludeFilesList": ["/directory/file/to/consider"]
+                    }
+                ]
+            }
+        )"_json;
+
+    std::filesystem::path dataSyncCommonCfgFile{dataSyncCfgDir /
+                                                "common_test_config.json"};
+    std::ofstream cfgFile(dataSyncCommonCfgFile);
+    ASSERT_TRUE(cfgFile.is_open())
+        << "Failed to open " << dataSyncCommonCfgFile;
+    cfgFile << commonJsonData;
+    cfgFile.close();
+
     std::unique_ptr<ed::ExternalDataIFaces> extDataIface =
         std::make_unique<ed::MockExternalDataIFaces>();
 

--- a/test/manager_test.hpp
+++ b/test/manager_test.hpp
@@ -17,38 +17,6 @@ class ManagerTest : public ::testing::Test
         dataSyncCfgDir = mkdtemp(tmpdir);
         char tmpDataDir[] = "/tmp/pdsDataDirXXXXXX";
         tmpDataSyncDataDir = mkdtemp(tmpDataDir);
-        commonJsonData = R"(
-                {
-                    "Files": [
-                        {
-                            "Path": "/file/path/to/sync",
-                            "Description": "Parse test file",
-                            "SyncDirection": "Active2Passive",
-                            "SyncType": "Immediate"
-                        }
-                    ],
-                    "Directories": [
-                        {
-                            "Path": "/directory/path/to/sync",
-                            "Description": "Parse test directory",
-                            "SyncDirection": "Passive2Active",
-                            "SyncType": "Periodic",
-                            "Periodicity": "PT1S",
-                            "RetryAttempts": 1,
-                            "RetryInterval": "PT10M",
-                            "ExcludeFilesList": ["/directory/file/to/ignore"],
-                            "IncludeFilesList": ["/directory/file/to/consider"]
-                        }
-                    ]
-                }
-            )"_json;
-        std::filesystem::path dataSyncCommonCfgFile{dataSyncCfgDir /
-                                                    "common_test_config.json"};
-        std::ofstream cfgFile(dataSyncCommonCfgFile);
-        ASSERT_TRUE(cfgFile.is_open())
-            << "Failed to open " << dataSyncCommonCfgFile;
-        cfgFile << commonJsonData;
-        cfgFile.close();
     }
 
     // Set up each individual test


### PR DESCRIPTION
 - Moved the commonJson data from SetUpTestSuite to ParseDataSyncCfg because the file and directory paths in commonJson were not pointing to valid locations, causing errors when accessed, This commonJson is specific to ParseDataSyncCfg, so it was moved there.

 - Also, in the test case, we need to define the external JSON to simulate different scenarios where the commonJson is not required.

Change-Id: I0ae93189ed165ac0f077227cfc8760e6af5a1bfb