### PR TITLE
Manager: Implement Disable Sync property

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -30,6 +30,13 @@ sdbusplus::async::task<> Manager::init()
     co_await sdbusplus::async::execution::when_all(
         parseConfiguration(), _extDataIfaces->startExtDataFetches());
 
+    if (_syncBMCDataIface.disable_sync())
+    {
+        lg2::info(
+            "Sync is Disabled, data sync cannot be performed to the sibling BMC.");
+        co_return;
+    }
+
     // TODO: Explore the possibility of running FullSync and Background Sync
     // concurrently
     if (_extDataIfaces->bmcRedundancy())
@@ -177,13 +184,35 @@ sdbusplus::async::task<>
     // NOLINTNEXTLINE
     Manager::monitorTimerToSync(const config::DataSyncConfig& dataSyncCfg)
 {
-    while (!_ctx.stop_requested())
+    while (!_ctx.stop_requested() && !_syncBMCDataIface.disable_sync())
     {
         co_await sdbusplus::async::sleep_for(
             _ctx, dataSyncCfg._periodicityInSec.value());
+        // Below is temporary check to avoid sync when disable sync is set to
+        // true.
+        // TODO: add receiver logic to stop sync events when disable sync is set
+        // to true.
+        if (_syncBMCDataIface.disable_sync())
+        {
+            break;
+        }
         co_await syncData(dataSyncCfg);
     }
     co_return;
+}
+
+void Manager::disableSyncPropChanged(bool disableSync)
+{
+    if (disableSync)
+    {
+        // TODO: Disable all sync events using Sender Receiver.
+        lg2::info("Sync is Disabled, Stopping events");
+    }
+    else
+    {
+        lg2::info("Sync is Enabled, Starting events");
+        _ctx.spawn(startSyncEvents());
+    }
 }
 
 // NOLINTNEXTLINE
@@ -199,6 +228,8 @@ sdbusplus::async::task<void> Manager::startFullSync()
 
     for (const auto& cfg : _dataSyncConfiguration)
     {
+        // TODO: add receiver logic to stop fullsync when disable sync is set to
+        // true.
         if (isSyncEligible(cfg))
         {
             _ctx.spawn(

--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -87,6 +87,26 @@ class Manager
         return _syncBMCDataIface.full_sync_status();
     }
 
+    /**
+     * @brief Helper API to start events when Disable sync property is changed.
+     *        - If the Disable sync property is set to true, it stops all sync
+     *          events. Otherwise, it starts all sync events.
+     *
+     * @param[in] disableSync - The Disable sync property value being set.
+     */
+    void disableSyncPropChanged(bool disableSync);
+
+    /**
+     * @brief Helper API to set the Disable sync Dbus status-property.
+     *        Specifically, for unit testing purposes.
+     *
+     * @param[in] disableSync - The Disable sync property value being set.
+     */
+    void setDisableSyncStatus(bool disableSync)
+    {
+        _syncBMCDataIface.disable_sync(disableSync);
+    }
+
   private:
     /**
      * @brief A helper API to start the data sync operation.

--- a/src/sync_bmc_data_ifaces.hpp
+++ b/src/sync_bmc_data_ifaces.hpp
@@ -51,6 +51,16 @@ class SyncBMCDataIface :
      */
     sdbusplus::async::task<> method_call(start_full_sync_t type);
 
+    /**
+     * @brief Implements property set for the disable sync property.
+     *
+     * @param[in] disable_sync_t - The type.
+     * @param[in] disable - the value being set.
+     *
+     * @return If the property value changed
+     */
+    bool set_property(disable_sync_t type, bool disable);
+
   private:
     /**
      * @brief Reference to the Manager object.

--- a/test/manager_test.cpp
+++ b/test/manager_test.cpp
@@ -78,3 +78,75 @@ TEST_F(ManagerTest, ParseDataSyncCfg)
     EXPECT_TRUE(
         manager.containsDataSyncCfg(ManagerTest::commonJsonData["Files"][0]));
 }
+
+TEST_F(ManagerTest, PeriodicDisablePropertyTest)
+{
+    using namespace std::literals;
+    namespace ed = data_sync::ext_data;
+
+    std::unique_ptr<ed::ExternalDataIFaces> extDataIface =
+        std::make_unique<ed::MockExternalDataIFaces>();
+
+    ed::MockExternalDataIFaces* mockExtDataIfaces =
+        dynamic_cast<ed::MockExternalDataIFaces*>(extDataIface.get());
+
+    ON_CALL(*mockExtDataIfaces, fetchBMCRedundancyMgrProps())
+        // NOLINTNEXTLINE
+        .WillByDefault([&mockExtDataIfaces]() -> sdbusplus::async::task<> {
+        mockExtDataIfaces->setBMCRole(ed::BMCRole::Active);
+        co_return;
+    });
+
+    EXPECT_CALL(*mockExtDataIfaces, fetchSiblingBmcIP())
+        // NOLINTNEXTLINE
+        .WillRepeatedly([]() -> sdbusplus::async::task<> { co_return; });
+
+    EXPECT_CALL(*mockExtDataIfaces, fetchRbmcCredentials())
+        // NOLINTNEXTLINE
+        .WillRepeatedly([]() -> sdbusplus::async::task<> { co_return; });
+
+    nlohmann::json jsonData = {
+        {"Files",
+         {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile2"},
+           {"DestinationPath",
+            ManagerTest::tmpDataSyncDataDir.string() + "/destFile2"},
+           {"Description", "Parse test file"},
+           {"SyncDirection", "Active2Passive"},
+           {"SyncType", "Periodic"},
+           {"Periodicity", "PT1S"}}}}};
+
+    std::string srcFile{jsonData["Files"][0]["Path"]};
+    std::string destFile{jsonData["Files"][0]["DestinationPath"]};
+
+    writeConfig(jsonData);
+    sdbusplus::async::context ctx;
+
+    std::string data{"Initial Data\n"};
+    ManagerTest::writeData(srcFile, data);
+
+    ASSERT_EQ(ManagerTest::readData(srcFile), data);
+
+    data_sync::Manager manager{ctx, std::move(extDataIface),
+                               ManagerTest::dataSyncCfgDir};
+    manager.setDisableSyncStatus(true); // disabled the sync events
+
+    EXPECT_NE(ManagerTest::readData(destFile), data)
+        << "The data should not match because the manager is spawned and"
+        << " is waiting for the periodic interval to initiate the sync.";
+
+    ctx.spawn(sdbusplus::async::sleep_for(ctx, 1.1s) |
+              sdbusplus::async::execution::then([&destFile, &data, &manager]() {
+        EXPECT_NE(ManagerTest::readData(destFile), data)
+            << "The data should not match as sync is disabled even though "
+            << "sync should take place every 1s as per config";
+        manager.setDisableSyncStatus(false); // Trigger the sync events
+    }));
+
+    ctx.spawn(
+        sdbusplus::async::sleep_for(ctx, 2.2s) |
+        sdbusplus::async::execution::then([&ctx]() { ctx.request_stop(); }));
+    ctx.run();
+    EXPECT_EQ(ManagerTest::readData(destFile), data)
+        << "The data should match with the data as 2.2s is passed"
+        << " and sync should take place every 1s as per config.";
+}


### PR DESCRIPTION
- This commit provides implementation of disable sync DBus property.
- If disable is set to true, we restrict starting FullSync and stop all future background sync.
- If this property is set to false (i.e., sync enabled), we trigger sync events (immediate and periodic).
- Tested on simics.

~~This PR cannot get merged, before [PR168](https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/168) for dbus-interfaces gets merged.~~

Change-Id: Ic7a6a63c1da74102405801d9e265c465f8a29af6
Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>
