### PR TITLE
Manager: Implement Sync Events Health property

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -166,8 +166,11 @@ sdbusplus::async::task<bool>
     int result = std::system(syncCmd.c_str()); // NOLINT
     if (result != 0)
     {
-        // TODO:
-        // Retry and create error log and disable redundancy if retry is failed.
+        // TODOs:
+        // 1. Retry based on rsync error code
+        // 2. Create error log and Disable redundancy if retry fails
+        // 3. Perform a callout
+        setSyncEventsHealth(SyncEventsHealth::Critical);
         lg2::error("Error syncing: {PATH}", "PATH", dataSyncCfg._path);
 
         co_return false;
@@ -300,6 +303,7 @@ sdbusplus::async::task<void> Manager::startFullSync()
                             [](const auto& result) { return result; }))
     {
         _syncBMCDataIface.full_sync_status(FullSyncStatus::FullSyncCompleted);
+        setSyncEventsHealth(SyncEventsHealth::Ok);
         lg2::info("Full Sync completed successfully");
     }
     else

--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -15,6 +15,8 @@ namespace data_sync
 
 using FullSyncStatus = sdbusplus::common::xyz::openbmc_project::control::
     SyncBMCData::FullSyncStatus;
+using SyncEventsHealth = sdbusplus::common::xyz::openbmc_project::control::
+    SyncBMCData::SyncEventsHealth;
 
 namespace fs = std::filesystem;
 
@@ -107,6 +109,26 @@ class Manager
         _syncBMCDataIface.disable_sync(disableSync);
     }
 
+    /**
+     * @brief Helper API fetches the sync events health Dbus property.
+     *        Specifically, for unit testing purposes.
+     */
+    SyncEventsHealth getSyncEventsHealth() const
+    {
+        return _syncBMCDataIface.sync_events_health();
+    }
+
+    /**
+     * @brief Helper API sets the sync events health Dbus property.
+     *
+     * @param[in] syncEventsHealth - The sync events health property value being
+     * set.
+     */
+    void setSyncEventsHealth(const SyncEventsHealth& syncEventsHealth)
+    {
+        _syncBMCDataIface.sync_events_health(syncEventsHealth);
+    }
+
   private:
     /**
      * @brief A helper API to start the data sync operation.
@@ -141,7 +163,7 @@ class Manager
      * @return Returns true if sync succeeds; otherwise, returns false
      *
      */
-    static sdbusplus::async::task<bool>
+    sdbusplus::async::task<bool>
         syncData(const config::DataSyncConfig& dataSyncCfg);
 
     /**

--- a/src/sync_bmc_data_ifaces.cpp
+++ b/src/sync_bmc_data_ifaces.cpp
@@ -62,6 +62,11 @@ bool SyncBMCDataIface::set_property([[maybe_unused]] disable_sync_t type,
     }
     disable_sync_ = disable;
     _manager.disableSyncPropChanged(disable);
+    if (sync_events_health_ != SyncEventsHealth::Critical)
+    {
+        _manager.setSyncEventsHealth(disable ? SyncEventsHealth::Paused
+                                             : SyncEventsHealth::Ok);
+    }
     return true;
 }
 


### PR DESCRIPTION
- This commit provides implementation of sync events health property.
- If sync is disabled, we mark sync events health as 'Paused'.
- When full sync completes successfully we mark sync events health as 'Ok'.
- If any of sync events fails, we mark sync events health as 'Critical'.
- Modified test cases.

Tested
- Verified on simics.

Change-Id: Ic99f090f1023ad49b9492410d64fcb19ebf75513
Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>