### PR TITLE
DataSync: Added DBus Serialization Utilities

### DIFF
--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -4,6 +4,7 @@
 
 #include "data_sync_config.hpp"
 #include "external_data_ifaces.hpp"
+#include "persistent.hpp"
 #include "sync_bmc_data_ifaces.hpp"
 
 #include <filesystem>
@@ -90,6 +91,13 @@ class Manager
     }
 
     /**
+     * @brief Helper API sets the full sync Dbus status-property.
+     *
+     * @param[in] fullSyncStatus - The Full Sync Status property being set.
+     */
+    void setFullSyncStatus(const FullSyncStatus& fullSyncStatus);
+
+    /**
      * @brief Helper API to start events when Disable sync property is changed.
      *        - If the Disable sync property is set to true, it stops all sync
      *          events. Otherwise, it starts all sync events.
@@ -124,10 +132,7 @@ class Manager
      * @param[in] syncEventsHealth - The sync events health property value being
      * set.
      */
-    void setSyncEventsHealth(const SyncEventsHealth& syncEventsHealth)
-    {
-        _syncBMCDataIface.sync_events_health(syncEventsHealth);
-    }
+    void setSyncEventsHealth(const SyncEventsHealth& syncEventsHealth);
 
   private:
     /**

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,6 +12,7 @@ rbmc_data_sync_sources = [
         'external_data_ifaces.cpp',
         'external_data_ifaces_impl.cpp',
         'manager.cpp',
+        'persistent.cpp',
         'sync_bmc_data_ifaces.cpp',
     ),
 ]

--- a/src/persistent.cpp
+++ b/src/persistent.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "persistent.hpp"
+
+#include "phosphor-logging/lg2.hpp"
+
+#include <format>
+#include <fstream>
+
+namespace data_sync::persist
+{
+std::filesystem::path DBusPropDataFile =
+    "/var/lib/phosphor-data-sync/persistence/dbus_props.json";
+
+std::optional<nlohmann::json> readFile(const std::filesystem::path& path)
+{
+    if (std::filesystem::exists(path))
+    {
+        std::ifstream stream{path};
+        try
+        {
+            return nlohmann::json::parse(stream);
+        }
+        catch (const std::exception& e)
+        {
+            lg2::error("Error parsing JSON in {FILE}: {ERROR}", "FILE", path,
+                       "ERROR", e);
+        }
+    }
+
+    return std::nullopt;
+}
+
+namespace util
+{
+
+void writeFile(const nlohmann::json& json, const std::filesystem::path& path)
+{
+    if (!std::filesystem::exists(path))
+    {
+        std::filesystem::create_directories(path.parent_path());
+    }
+    std::ofstream stream{path};
+    stream << std::setw(4) << json;
+    if (stream.fail())
+    {
+        throw std::runtime_error{
+            std::format("Failed writing {}", path.string())};
+    }
+}
+
+} // namespace util
+
+} // namespace data_sync::persist

--- a/src/persistent.hpp
+++ b/src/persistent.hpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <optional>
+
+namespace data_sync::persist
+{
+
+extern std::filesystem::path DBusPropDataFile;
+
+namespace key
+{
+constexpr auto disable = "Disable";
+constexpr auto fullSyncStatus = "FullSyncStatus";
+constexpr auto syncEventsHealth = "SyncEventsHealth";
+} // namespace key
+
+namespace util
+{
+
+/**
+ * @brief Helper function to update a JSON file
+ *
+ * @param[in] json - The JSON to update
+ * @param[in] path - The path to the file
+ */
+void writeFile(const nlohmann::json& json, const std::filesystem::path& path);
+
+} // namespace util
+
+/**
+ * @brief Function to read a JSON file
+ *
+ * @param[in] path - The path to the file
+ *
+ * @return optional<json> - The JSON data, or std::nullopt if it
+ *                          didn't exist or was corrupt.
+ */
+std::optional<nlohmann::json> readFile(const std::filesystem::path& path);
+
+/**
+ * @brief Updates "name": <value>  JSON to the file specified
+ *
+ * @tparam - The data type
+ * @param[in] name - The key to save the value under
+ * @param[in] value - The value to save
+ */
+template <typename T>
+void update(std::string_view name, const T& value,
+            const std::filesystem::path& path = DBusPropDataFile)
+{
+    auto json = readFile(path).value_or(nlohmann::json::object());
+    if constexpr (std::is_enum_v<T>)
+    {
+        json[name] = std::to_underlying(value);
+    }
+    else
+    {
+        json[name] = value;
+    }
+    util::writeFile(json, path);
+}
+
+/**
+ * @brief Reads the value of the key specified in the file specified
+ *        Specifically, for unit testing purposes.
+ *
+ * @tparam T - The data type
+ * @param[in] name - The key the value is saved under
+ * @param[in] path - The path to the file
+ *
+ * @return optional<T> - The value, or std::nullopt if the file or
+ *                       key isn't present.
+ */
+template <typename T>
+std::optional<T> read(std::string_view name,
+                      const std::filesystem::path& path = DBusPropDataFile)
+{
+    auto json = readFile(path);
+    if (!json)
+    {
+        return std::nullopt;
+    }
+
+    auto it = json->find(name);
+    if (it != json->end())
+    {
+        if constexpr (std::is_enum_v<T>)
+        {
+            auto value = it->get<std::underlying_type_t<T>>();
+            return static_cast<T>(value);
+        }
+        else
+        {
+            return it->get<T>();
+        }
+    }
+
+    return std::nullopt;
+}
+
+} // namespace data_sync::persist

--- a/src/sync_bmc_data_ifaces.hpp
+++ b/src/sync_bmc_data_ifaces.hpp
@@ -44,6 +44,12 @@ class SyncBMCDataIface :
                      data_sync::Manager& manager);
 
     /**
+     * @brief Reads from the persistence file and sets the property values if
+     * available.
+     */
+    void restoreDBusProperties();
+
+    /**
      * @brief Handles the FullSync method call for the SyncBmcData interface,
      *
      * @param[in] type Method type identifier.

--- a/test/manager_test.cpp
+++ b/test/manager_test.cpp
@@ -5,6 +5,11 @@ std::filesystem::path ManagerTest::dataSyncCfgDir;
 std::filesystem::path ManagerTest::tmpDataSyncDataDir;
 nlohmann::json ManagerTest::commonJsonData;
 
+using FullSyncStatus = sdbusplus::common::xyz::openbmc_project::control::
+    SyncBMCData::FullSyncStatus;
+using SyncEventsHealth = sdbusplus::common::xyz::openbmc_project::control::
+    SyncBMCData::SyncEventsHealth;
+
 TEST_F(ManagerTest, ParseDataSyncCfg)
 {
     using namespace std::literals;
@@ -36,13 +41,7 @@ TEST_F(ManagerTest, ParseDataSyncCfg)
             }
         )"_json;
 
-    std::filesystem::path dataSyncCommonCfgFile{dataSyncCfgDir /
-                                                "common_test_config.json"};
-    std::ofstream cfgFile(dataSyncCommonCfgFile);
-    ASSERT_TRUE(cfgFile.is_open())
-        << "Failed to open " << dataSyncCommonCfgFile;
-    cfgFile << commonJsonData;
-    cfgFile.close();
+    writeConfig(commonJsonData);
 
     std::unique_ptr<ed::ExternalDataIFaces> extDataIface =
         std::make_unique<ed::MockExternalDataIFaces>();
@@ -77,4 +76,131 @@ TEST_F(ManagerTest, ParseDataSyncCfg)
 
     EXPECT_TRUE(manager.containsDataSyncCfg(data_sync::config::DataSyncConfig(
         ManagerTest::commonJsonData["Files"][0], false)));
+}
+
+TEST_F(ManagerTest, testDBusDataPersistency)
+{
+    using namespace std::literals;
+    namespace ed = data_sync::ext_data;
+
+    std::unique_ptr<ed::ExternalDataIFaces> extDataIface =
+        std::make_unique<ed::MockExternalDataIFaces>();
+
+    ed::MockExternalDataIFaces* mockExtDataIfaces =
+        dynamic_cast<ed::MockExternalDataIFaces*>(extDataIface.get());
+
+    ON_CALL(*mockExtDataIfaces, fetchBMCRedundancyMgrProps())
+        // NOLINTNEXTLINE
+        .WillByDefault([&mockExtDataIfaces]() -> sdbusplus::async::task<> {
+        mockExtDataIfaces->setBMCRole(ed::BMCRole::Active);
+        mockExtDataIfaces->setBMCRedundancy(true);
+        co_return;
+    });
+
+    EXPECT_CALL(*mockExtDataIfaces, fetchSiblingBmcIP())
+        // NOLINTNEXTLINE
+        .WillRepeatedly([]() -> sdbusplus::async::task<> { co_return; });
+
+    EXPECT_CALL(*mockExtDataIfaces, fetchRbmcCredentials())
+        // NOLINTNEXTLINE
+        .WillRepeatedly([]() -> sdbusplus::async::task<> { co_return; });
+
+    nlohmann::json jsonData = {
+        {"Files",
+         {
+             {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile1"},
+              {"DestinationPath",
+               ManagerTest::tmpDataSyncDataDir.string() + "/destFile1"},
+              {"Description", "FullSync from Active to Passive bmc"},
+              {"SyncDirection", "Active2Passive"},
+              {"SyncType", "Immediate"}},
+             {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile2"},
+              {"DestinationPath",
+               ManagerTest::tmpDataSyncDataDir.string() + "/destFile2"},
+              {"Description", "FullSync from Active to Passive bmc"},
+              {"SyncDirection", "Active2Passive"},
+              {"SyncType", "Immediate"}},
+         }}};
+
+    std::string srcFile1{jsonData["Files"][0]["Path"]};
+    std::string srcFile2{jsonData["Files"][1]["Path"]};
+
+    std::string destFile1{jsonData["Files"][0]["DestinationPath"]};
+    std::string destFile2{jsonData["Files"][1]["DestinationPath"]};
+
+    writeConfig(jsonData);
+    sdbusplus::async::context ctx;
+
+    std::string data1{"Data written on the file1\n"};
+    std::string data2{"Data written on the file2\n"};
+
+    ManagerTest::writeData(srcFile1, data1);
+    ManagerTest::writeData(srcFile2, data2);
+
+    ASSERT_EQ(ManagerTest::readData(srcFile1), data1);
+    ASSERT_EQ(ManagerTest::readData(srcFile2), data2);
+
+    // Before starting manager we write to persistent file: SyncEventsHealth as
+    // Critical and FullSyncStatus as In Progress. After manager starts, it
+    // should load the persistent data as defined.
+    data_sync::persist::update(data_sync::persist::key::fullSyncStatus,
+                               FullSyncStatus::FullSyncInProgress);
+    data_sync::persist::update(data_sync::persist::key::syncEventsHealth,
+                               SyncEventsHealth::Critical);
+    data_sync::Manager manager{ctx, std::move(extDataIface),
+                               ManagerTest::dataSyncCfgDir};
+
+    EXPECT_EQ(data_sync::persist::read<FullSyncStatus>(
+                  data_sync::persist::key::fullSyncStatus),
+              FullSyncStatus::FullSyncInProgress);
+    EXPECT_EQ(manager.getFullSyncStatus(), FullSyncStatus::FullSyncInProgress)
+        << "FullSyncInProgress is not set to InProgress in persistent file.";
+
+    EXPECT_EQ(data_sync::persist::read<SyncEventsHealth>(
+                  data_sync::persist::key::syncEventsHealth),
+              SyncEventsHealth::Critical);
+    EXPECT_EQ(manager.getSyncEventsHealth(), SyncEventsHealth::Critical)
+        << "SyncEventsHealth is not set to Critical in persistent file.";
+
+    auto waitingForFullSyncToFinish =
+        // NOLINTNEXTLINE
+        [&](sdbusplus::async::context& ctx) -> sdbusplus::async::task<void> {
+        auto status = manager.getFullSyncStatus();
+
+        while (status != FullSyncStatus::FullSyncCompleted &&
+               status != FullSyncStatus::FullSyncFailed)
+        {
+            co_await sdbusplus::async::sleep_for(ctx,
+                                                 std::chrono::milliseconds(50));
+            status = manager.getFullSyncStatus();
+        }
+
+        EXPECT_EQ(status, FullSyncStatus::FullSyncCompleted)
+            << "FullSync status is not Completed!";
+
+        EXPECT_EQ(ManagerTest::readData(destFile1), data1);
+        EXPECT_EQ(ManagerTest::readData(destFile2), data2);
+
+        ctx.request_stop();
+
+        // After successfull completion of full sync, the DBUS property must be
+        // updated and stored. Reading and confirming the values.
+        EXPECT_EQ(data_sync::persist::read<FullSyncStatus>(
+                      data_sync::persist::key::fullSyncStatus),
+                  FullSyncStatus::FullSyncCompleted);
+        EXPECT_EQ(data_sync::persist::read<SyncEventsHealth>(
+                      data_sync::persist::key::syncEventsHealth),
+                  SyncEventsHealth::Ok);
+
+        // Forcing to trigger inotify events so that all running immediate
+        // sync tasks will resume and stop since the context is requested to
+        // stop in the above.
+        ManagerTest::writeData(srcFile1, data1);
+        ManagerTest::writeData(srcFile2, data2);
+        co_return;
+    };
+
+    ctx.spawn(waitingForFullSyncToFinish(ctx));
+
+    ctx.run();
 }

--- a/test/manager_test.hpp
+++ b/test/manager_test.hpp
@@ -17,6 +17,8 @@ class ManagerTest : public ::testing::Test
         dataSyncCfgDir = mkdtemp(tmpdir);
         char tmpDataDir[] = "/tmp/pdsDataDirXXXXXX";
         tmpDataSyncDataDir = mkdtemp(tmpDataDir);
+        data_sync::persist::DBusPropDataFile = tmpDataSyncDataDir /
+                                               "persistentData.json";
     }
 
     // Set up each individual test

--- a/test/meson.build
+++ b/test/meson.build
@@ -25,6 +25,7 @@ test_source_files = [
     'periodic_sync_test',
     'full_sync_test',
     'immediate_sync_test',
+    'persistent_data_test',
 ]
 
 foreach test_file : test_source_files

--- a/test/persistent_data_test.cpp
+++ b/test/persistent_data_test.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "manager_test.hpp"
+
+std::filesystem::path ManagerTest::dataSyncCfgDir;
+std::filesystem::path ManagerTest::tmpDataSyncDataDir;
+
+using FullSyncStatus = sdbusplus::common::xyz::openbmc_project::control::
+    SyncBMCData::FullSyncStatus;
+using SyncEventsHealth = sdbusplus::common::xyz::openbmc_project::control::
+    SyncBMCData::SyncEventsHealth;
+
+TEST_F(ManagerTest, testReadWritePersistencyFile)
+{
+    // Write
+    data_sync::persist::update("Disable", true);
+    data_sync::persist::update("FullSyncStatus",
+                               FullSyncStatus::FullSyncInProgress);
+    data_sync::persist::update("SyncEventsHealth", SyncEventsHealth::Critical);
+
+    // Read back
+    EXPECT_EQ(data_sync::persist::read<bool>("Disable"), true);
+    EXPECT_EQ(data_sync::persist::read<FullSyncStatus>("FullSyncStatus"),
+              FullSyncStatus::FullSyncInProgress);
+    EXPECT_EQ(data_sync::persist::read<SyncEventsHealth>("SyncEventsHealth"),
+              SyncEventsHealth::Critical);
+
+    // Write new values
+    data_sync::persist::update("Disable", false);
+    data_sync::persist::update("FullSyncStatus",
+                               FullSyncStatus::FullSyncCompleted);
+    data_sync::persist::update("SyncEventsHealth", SyncEventsHealth::Ok);
+
+    // Read back the new values
+    EXPECT_EQ(data_sync::persist::read<bool>("Disable"), false);
+    EXPECT_EQ(data_sync::persist::read<FullSyncStatus>("FullSyncStatus"),
+              FullSyncStatus::FullSyncCompleted);
+    EXPECT_EQ(data_sync::persist::read<SyncEventsHealth>("SyncEventsHealth"),
+              SyncEventsHealth::Ok);
+
+    // Some different types - write
+    data_sync::persist::update("EmptyString", std::string{});
+    data_sync::persist::update("VectorOfStrings",
+                               std::vector<std::string>{"a", "b"});
+    data_sync::persist::update("EmptyVector", std::vector<std::string>{});
+
+    // Some different types - read back
+    EXPECT_EQ(data_sync::persist::read<std::string>("EmptyString"),
+              std::string{});
+    EXPECT_EQ(
+        data_sync::persist::read<std::vector<std::string>>("VectorOfStrings"),
+        (std::vector<std::string>{"a", "b"}));
+    EXPECT_EQ(data_sync::persist::read<std::vector<std::string>>("EmptyVector"),
+              (std::vector<std::string>{}));
+
+    // Key doesn't exist
+    EXPECT_EQ(data_sync::persist::read<bool>("Blah"), std::nullopt);
+
+    // File doesn't exist
+    EXPECT_EQ(data_sync::persist::read<bool>("Disable", "/blah/blah"),
+              std::nullopt);
+
+    // Invalid JSON
+    std::filesystem::remove(data_sync::persist::DBusPropDataFile);
+    std::ofstream file{data_sync::persist::DBusPropDataFile};
+    const char* data = R"(
+        {
+            "FullSyncStatus": 1,
+            Bool 0
+        }
+    )";
+    file << data;
+    file.close();
+
+    EXPECT_EQ(data_sync::persist::read<FullSyncStatus>(
+                  "FullSyncStatus", data_sync::persist::DBusPropDataFile),
+              std::nullopt);
+}


### PR DESCRIPTION
- A JSON file was chosen so it's easy to see all the values at once and to capture them all in a dump or error log.
- Stores and Restores DBUS properties: 'FullSyncStatus', 'SyncEventsHealth' and 'DisableSync'
- Writes to the JSON whenever there's a change to above DBus properties.
- Design is compatible with introduction of new DBus properties.

Tested
- Added test cases.
- Verified on simics. Example JSON file generated:
```bash
$ cat /var/lib/phosphor-data-sync/persistence/dbus_props.json
{
    "Disable": false,
    "FullSyncStatus": 2,
    "SyncEventsHealth": 2
}
```

Change-Id: Id6e2acb1b9b692e5925b9fcab61dec9eef6bbbff
Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>