### PR TITLE
immediate-sync : Avoid the unwanted IN_CREATE event processing

### DIFF
--- a/src/data_watcher.cpp
+++ b/src/data_watcher.cpp
@@ -184,7 +184,7 @@ std::optional<DataOperation>
         return processCloseWrite(receivedEventInfo);
     }
     else if ((std::get<EventMask>(receivedEventInfo) &
-              (IN_CREATE | IN_ISDIR)) != 0)
+              (IN_CREATE | IN_ISDIR)) == (IN_CREATE | IN_ISDIR))
     {
         /**
          * Handle the creation of directories inside a monitoring DIR


### PR DESCRIPTION
It is observed that while deleting the watching directories, it triggers the processing of IN_CREATE event also along with IN_DELETE_SELF processing which is not expected.

Root cause :

On analysis, it is figured out that delete operation of watching directories will emit IN_DELETE_SELF | IN_ISDIR which was passing the condition to invoke processCreate API also as it's check was mistakenly checking whether any of bits corresponds to IN_CREATE or IN_ISDIR set instead of checking both IN_CREATE and IN_ISDIR bit checking.

Solution :

Corrected the condition to invoke processCreate() with correct bit operations.

Tested :

- Verified in simics that no more processing of IN_CREATE events during deletion of watching directories.

Change-Id: I74ab7c59879567e915cee00cc47a7b4cd7364c9d