### PR TITLE
FullSync: Temporarily force Full Sync to always succeed

### DIFF
--- a/test/full_sync_test.cpp
+++ b/test/full_sync_test.cpp
@@ -619,10 +619,16 @@ TEST_F(ManagerTest, FullSyncFailed)
             status = manager.getFullSyncStatus();
         }
 
-        EXPECT_EQ(status, FullSyncStatus::FullSyncFailed)
-            << "FullSync status is not Failed!!";
-        EXPECT_EQ(manager.getSyncEventsHealth(), SyncEventsHealth::Critical)
-            << "SyncEventsHealth should be Critical.";
+        // NOTE: The following test checks are commented out temporarily.
+        // Since Full Sync is currently forced to always succeed (even if
+        // syncing fails), there is no failure scenario being triggered, and
+        // these tests will not pass. These checks should be re-enabled once
+        // proper Full Sync failure handling is implemented
+
+        // EXPECT_EQ(status, FullSyncStatus::FullSyncFailed)
+        // << "FullSync status is not Failed!!";
+        // EXPECT_EQ(manager.getSyncEventsHealth(), SyncEventsHealth::Critical)
+        // << "SyncEventsHealth should be Critical.";
 
         EXPECT_EQ(ManagerTest::readData(destFile1), data1);
         EXPECT_EQ(ManagerTest::readData(destFile2), data2);


### PR DESCRIPTION
    - Force Full Sync to always report success, even if data sync fails
    - Always set SyncEventsHealth to 'Ok' after sync attempt, regardless of success or failure
    - This is a temporary change to unblock development and testing Will be reverted after proper error handling is implemented

Change-Id: I49d2eb48a078bb5301772678d4a8fb26cbea8b06