### PR TITLE
Add the support to handle IN_MOVED_TO and IN_MOVED_FROM inotify events

### DIFF
--- a/src/data_watcher.cpp
+++ b/src/data_watcher.cpp
@@ -189,6 +189,16 @@ void DataWatcher::processEvents(
 std::optional<DataOperation>
     DataWatcher::processEvent(const EventInfo& receivedEventInfo)
 {
+    // No current use case for data-sync to support hidden files
+    if (std::get<BaseName>(receivedEventInfo).starts_with("."))
+    {
+        lg2::debug("Ignoring the EVENT[{MASK}] as received for the hidden "
+                   "file[{PATH}]",
+                   "MASK", std::get<2>(receivedEventInfo), "PATH",
+                   std::get<BaseName>(receivedEventInfo));
+        return std::nullopt;
+    }
+
     if ((std::get<2>(receivedEventInfo) & IN_CLOSE_WRITE) != 0)
     {
         return processCloseWrite(receivedEventInfo);

--- a/src/data_watcher.hpp
+++ b/src/data_watcher.hpp
@@ -25,7 +25,8 @@ namespace fs = std::filesystem;
 using WD = int;
 using BaseName = std::string;
 using EventMask = uint32_t;
-using EventInfo = std::tuple<WD, BaseName, EventMask>;
+using Cookie = uint32_t;
+using EventInfo = std::tuple<WD, BaseName, EventMask, Cookie>;
 
 /**
  * @brief enum which indicates the type of operations that can take against an
@@ -262,6 +263,18 @@ class DataWatcher
      */
     std::optional<DataOperation>
         processCreate(const EventInfo& receivedEventInfo);
+
+    /**
+     * @brief API to handle the received IN_MOVED_TO inotify events
+     *
+     * @param[in] receivedEventInfo : eventInfo type which has the information
+     *                                of received  inotify event.
+     *
+     * @returns DataOperation : If the received event need to handle in rsync
+     *          std::nullopt  : If the received event doesn't need to handle.
+     */
+    std::optional<DataOperation>
+        processMovedTo(const EventInfo& receivedEventInfo);
 
     /**
      * @brief API to handle the received IN_DELETE inotify events

--- a/src/data_watcher.hpp
+++ b/src/data_watcher.hpp
@@ -265,6 +265,18 @@ class DataWatcher
         processCreate(const EventInfo& receivedEventInfo);
 
     /**
+     * @brief API to handle the received IN_MOVED_FROM inotify events
+     *
+     * @param[in] receivedEventInfo : eventInfo type which has the information
+     *                                of received  inotify event.
+     *
+     * @returns DataOperation : If the received event need to handle in rsync
+     *          std::nullopt  : If the received event doesn't need to handle.
+     */
+    std::optional<DataOperation>
+        processMovedFrom(const EventInfo& receivedEventInfo);
+
+    /**
      * @brief API to handle the received IN_MOVED_TO inotify events
      *
      * @param[in] receivedEventInfo : eventInfo type which has the information

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -178,6 +178,7 @@ sdbusplus::async::task<bool>
     syncCmd.append(dataSyncCfg._destPath.value_or(fs::path("")));
     lg2::debug("RSYNC CMD : {CMD}", "CMD", syncCmd);
     int result = std::system(syncCmd.c_str()); // NOLINT
+
     if (result != 0)
     {
         // TODOs:
@@ -204,7 +205,7 @@ sdbusplus::async::task<>
 {
     try
     {
-        uint32_t eventMasksToWatch = IN_CLOSE_WRITE | IN_DELETE_SELF;
+        uint32_t eventMasksToWatch = IN_CLOSE_WRITE | IN_MOVE | IN_DELETE_SELF;
         if (dataSyncCfg._isPathDir)
         {
             eventMasksToWatch |= IN_CREATE | IN_DELETE;

--- a/test/immediate_sync_test.cpp
+++ b/test/immediate_sync_test.cpp
@@ -433,3 +433,112 @@ TEST_F(ManagerTest, testDataCreateInSubDir)
 
     ctx.run();
 }
+
+TEST_F(ManagerTest, testFileMoveToAnotherDir)
+{
+    using namespace std::literals;
+    namespace extData = data_sync::ext_data;
+
+    std::unique_ptr<extData::ExternalDataIFaces> extDataIface =
+        std::make_unique<extData::MockExternalDataIFaces>();
+
+    extData::MockExternalDataIFaces* mockExtDataIfaces =
+        dynamic_cast<extData::MockExternalDataIFaces*>(extDataIface.get());
+
+    ON_CALL(*mockExtDataIfaces, fetchBMCRedundancyMgrProps())
+        // NOLINTNEXTLINE
+        .WillByDefault([&mockExtDataIfaces]() -> sdbusplus::async::task<> {
+        mockExtDataIfaces->setBMCRole(extData::BMCRole::Active);
+        co_return;
+    });
+
+    EXPECT_CALL(*mockExtDataIfaces, fetchSiblingBmcIP())
+        // NOLINTNEXTLINE
+        .WillRepeatedly([]() -> sdbusplus::async::task<> { co_return; });
+
+    EXPECT_CALL(*mockExtDataIfaces, fetchRbmcCredentials())
+        // NOLINTNEXTLINE
+        .WillRepeatedly([]() -> sdbusplus::async::task<> { co_return; });
+
+    nlohmann::json jsonData = {
+        {"Directories",
+         {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcDir1/"},
+           {"DestinationPath",
+            ManagerTest::tmpDataSyncDataDir.string() + "/destDir1/"},
+           {"Description", "Directory to test immediate sync on file move"},
+           {"SyncDirection", "Active2Passive"},
+           {"SyncType", "Immediate"}},
+          {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcDir2/"},
+           {"DestinationPath",
+            ManagerTest::tmpDataSyncDataDir.string() + "/destDir2/"},
+           {"Description", "Directory to test immediate sync on file move"},
+           {"SyncDirection", "Active2Passive"},
+           {"SyncType", "Immediate"}}}}};
+
+    fs::path srcPath1{jsonData["Directories"][0]["Path"]};
+    fs::path srcPath2{jsonData["Directories"][1]["Path"]};
+    fs::path destDir1{jsonData["Directories"][0]["DestinationPath"]};
+    fs::path destDir2{jsonData["Directories"][1]["DestinationPath"]};
+    fs::path destPath1 = destDir1 / fs::relative(srcPath1, "/");
+    fs::path destPath2 = destDir2 / fs::relative(srcPath2, "/");
+
+    writeConfig(jsonData);
+    sdbusplus::async::context ctx;
+
+    std::string data{"Src: Initial Data\n"};
+    fs::create_directory(srcPath1);
+    fs::create_directory(srcPath2);
+    ManagerTest::writeData(srcPath1 / "Test", data);
+    ASSERT_EQ(ManagerTest::readData(srcPath1 / "Test"), data);
+    ASSERT_FALSE(fs::exists(srcPath2 / "Test"));
+
+    // Create dest paths
+    std::string destData{"Dest: Initial Data\n"};
+    fs::create_directories(destPath1);
+    fs::create_directories(destPath2);
+    ASSERT_TRUE(fs::exists(destPath1));
+    ASSERT_TRUE(fs::exists(destPath2));
+    ManagerTest::writeData(destPath1 / "Test", destData);
+    ASSERT_EQ(ManagerTest::readData(destPath1 / "Test"), destData);
+    ASSERT_FALSE(fs::exists(destPath2 / "Test"));
+
+    data_sync::Manager manager{ctx, std::move(extDataIface),
+                               ManagerTest::dataSyncCfgDir};
+
+    // Case : File "Test" will move from srcPath1 to srcPath2
+    // File "Test" will get delete from destPath1
+    // File "Test" will get create at destPath2
+
+    // Watch dest paths for data change
+    data_sync::watch::inotify::DataWatcher dataWatcher1(ctx, IN_NONBLOCK,
+                                                        IN_DELETE, destPath1);
+    data_sync::watch::inotify::DataWatcher dataWatcher2(ctx, IN_NONBLOCK,
+                                                        IN_CREATE, destPath2);
+
+    ctx.spawn(dataWatcher1.onDataChange() |
+              sdbusplus::async::execution::then(
+                  [&destPath1]([[maybe_unused]] const auto& dataOps) {
+        EXPECT_FALSE(fs::exists(destPath1 / "Test"));
+    }));
+
+    ctx.spawn(dataWatcher2.onDataChange() |
+              sdbusplus::async::execution::then(
+                  [&data, &destPath2]([[maybe_unused]] const auto& dataOps) {
+        EXPECT_TRUE(fs::exists(destPath2 / "Test"));
+        EXPECT_EQ(ManagerTest::readData(destPath2 / "Test"), data);
+    }));
+
+    // Move file after 1s so that the background sync events will be ready
+    // to catch.
+    ctx.spawn(sdbusplus::async::sleep_for(ctx, 1s) |
+              sdbusplus::async::execution::then(
+                  [&ctx, &srcPath1, &srcPath2, &data]() {
+        fs::rename(srcPath1 / "Test", srcPath2 / "Test");
+        EXPECT_FALSE(fs::exists(srcPath1 / "Test"));
+        EXPECT_TRUE(fs::exists(srcPath2 / "Test"));
+        ASSERT_EQ(ManagerTest::readData(srcPath2 / "Test"), data);
+        ctx.request_stop();
+    }));
+
+    ctx.run();
+}


### PR DESCRIPTION
This PR commits is dependent on PR21 and PR26 , which are yet to merge and contains the commits from PR21 and PR26 also. Hence review the below mentioned commits.

1. [inotify : process the IN_MOVED_TO signal](https://github.com/ibm-openbmc/phosphor-data-sync/commit/3adad6cce423c2ec2dd3696305897aa12c1add9d)
2. [inotify : Process IN_MOVED_FROM signal](https://github.com/ibm-openbmc/phosphor-data-sync/commit/feec13e889cd496a1d1c28f4369b452e89fa50eb)
3. [inotify : Watch for IN_MOVED_FROM and IN_MOVED_TO signals](https://github.com/ibm-openbmc/phosphor-data-sync/commit/8bf67403377ec8c3a79969b3f2e201de0b3f0017)

