### PR TITLE
rsync : sync only the modified data path via Rsync

### DIFF
--- a/src/data_sync_config.hpp
+++ b/src/data_sync_config.hpp
@@ -5,12 +5,15 @@
 #include <nlohmann/json.hpp>
 
 #include <chrono>
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <string_view>
 
 namespace data_sync::config
 {
+
+namespace fs = std::filesystem;
 
 /**
  * @brief The enum contains all the sync directions.
@@ -130,7 +133,7 @@ struct DataSyncConfig
     /**
      * @brief The file or directory path to be synchronized.
      */
-    std::string _path;
+    fs::path _path;
 
     /**
      * @brief Bool flag to indicate whether the path is file or directory
@@ -140,7 +143,7 @@ struct DataSyncConfig
     /**
      * @brief The file or directory path to the destination to be synchronized.
      */
-    std::optional<std::string> _destPath;
+    std::optional<fs::path> _destPath;
 
     /**
      * @brief Used to get sync direction.

--- a/src/data_watcher.cpp
+++ b/src/data_watcher.cpp
@@ -181,8 +181,7 @@ void DataWatcher::processEvents(
         std::optional<DataOperation> dataOperation = processEvent(event);
         if (dataOperation.has_value())
         {
-            _dataOperations.insert_or_assign(dataOperation.value().first,
-                                             dataOperation.value().second);
+            _dataOperations.emplace_back(dataOperation.value());
         }
     });
 }

--- a/src/data_watcher.hpp
+++ b/src/data_watcher.hpp
@@ -38,14 +38,17 @@ enum class DataOps
 };
 
 /**
- * @brief A map which tells what type of operations need to perform on the data
- * path against an intersted inotify event.
+ * @brief Container holding data paths and their corresponding operations.
  *
- * fs::path - absolute path of the modified data
- * DataOps  - Type of action need to perform on the data path
+ * Represents a list of data paths and the type of operation,that needs to be
+ * performed on each path.
+ *
+ * Each entry is a pair of :
+ * - fs::path : Absolute path of the file or directory
+ * - DataOps  : Operation to perform on the given path
  */
-using DataOperations = std::map<fs::path, DataOps>;
 using DataOperation = std::pair<fs::path, DataOps>;
+using DataOperations = std::vector<DataOperation>;
 
 /** @class FD
  *

--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -169,7 +169,8 @@ class Manager
      *
      */
     sdbusplus::async::task<bool>
-        syncData(const config::DataSyncConfig& dataSyncCfg);
+        syncData(const config::DataSyncConfig& dataSyncCfg,
+                 fs::path srcPath = fs::path{});
 
     /**
      * @brief A helper to API to monitor data to sync if its changed


### PR DESCRIPTION
The commit modifies the syncData API which enables RSYNC to sync only the modified data path if available as SRC path instead of syncing the configured data path every time.

The change also modifies the file paths data type to std::filesystem::path for optimized performance.

Change-Id: Iac4bb9367ab84b34193e577999ae417ab38fe1e5