### PR TITLE
config: Add sync config for host console log files

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -1,4 +1,20 @@
 {
+    "Files": [
+        {
+            "Path": "/var/log/obmc-console.log",
+            "Description": "Host console persisted log data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Periodic",
+            "Periodicity": "PT60S"
+        },
+        {
+            "Path": "/var/log/obmc-console1.log",
+            "Description": "Host console1 persisted log data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Periodic",
+            "Periodicity": "PT60S"
+        }
+    ],
     "Directories": [
         {
             "Path": "/var/lib/phosphor-state-manager/host{}-PersistData/",


### PR DESCRIPTION
This commit adds '/var/log/obmc-console.log' and '/var/log/ obmc-console1.log' to the sync configuration to ensure host boot and IPL logs are available on both BMCs

These files capture critical boot-related logs, including SBE and Hostboot (PHYP and OS) istep data. Syncing them helps preserve historical context of host boot attempts, which is useful for debugging, especially after a BMC failover