### PR TITLE
config: Add sync config for OCC control data

### DIFF
--- a/config/data_sync_list/open-power.json
+++ b/config/data_sync_list/open-power.json
@@ -6,5 +6,13 @@
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
         }
+    ],
+    "Directories": [
+        {
+            "Path": "/var/lib/openpower-occ-control/",
+            "Description": "BMC-OCC persisted data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
+        }
     ]
 }


### PR DESCRIPTION
This commit adds '/var/lib/openpower-occ-control/' to the sync configuration to ensure OCC-related data is preserved across BMCs
