### PR TITLE
config: fan: Fix, update the exclude list key

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -11,7 +11,7 @@
             "Description": "Fan presence persisted data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate",
-            "ExcludeList": ["/var/lib/phosphor-fan-presence/control/"]
+            "ExcludeFilesList": ["/var/lib/phosphor-fan-presence/control/"]
         }
     ]
 }


### PR DESCRIPTION
The key to configure the exclude paths is changed from "ExcludeList" to "ExcludeFilesList and missed to update in the phosphor-fan-presence component so fixing the same

Change-Id: I2723d9fb90329b309bafb23beaeb3067933e2bb9