### PR TITLE
inotify : Avoid unnecessary rsync during bidirectional sync

### DIFF
--- a/src/data_watcher.hpp
+++ b/src/data_watcher.hpp
@@ -180,6 +180,14 @@ class DataWatcher
     DataOperations _dataOperations;
 
     /**
+     * @brief Map of Cookie and DataOperation to save the inotify event info.
+     *
+     * Eg : The IN_MOVED_FROM info during the rename or move operations can be
+     * saved for map to the corresponding IN_MOVED_TO signals.
+     */
+    std::map<Cookie, DataOperation> _movedFromDataOps;
+
+    /**
      * @brief initialize an inotify instance and returns file descriptor
      */
     int inotifyInit() const;


### PR DESCRIPTION
 - During bidirectional sync operations, rsync creates hidden temporary files at the destination before renaming them to their final names. This results in:

    - IN_MOVED_FROM events for the hidden temporary files.
    - IN_MOVED_TO events for the actual target files.

 - The IN_MOVED_FROM events from hidden files were ignored, and IN_MOVED_TO events would trigger another sync, potentially causing unnecessary operations.

Hence this commit introduces the following changes:

 - Temporarily store all IN_MOVED_FROM events.

 - Only process IN_MOVED_TO events if the corresponding IN_MOVED_FROM was from a non-hidden file.

 - Ignore processing IN_MOVED_FROM events that originate from hidden temporary files created by rsync.

 - This ensures that sync is triggered only for genuine file moves and avoids redundant rsync operations for temporary files.

Tested:

Verified the following in the huygens simics model:
    - No IN_MOVED_FROM signals whichreceived for the hidden files initiates sync operation.
    - No IN_MOVED_TO signals is being processed in RSYNC layer if the corresponding IN_MOVED_FROM is for hidden temporary files.
    - All IN_MOVED_FROM and IN_MOVED_TO signals triggers as part of move operation is handled properly.

Change-Id: Iea4bfb5bf74cffbe03602e6f82d3b37973aa9f27