### PR TITLE
config: Add sync config for host POST code data

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -28,6 +28,13 @@
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate",
             "ExcludeFilesList": ["/var/lib/phosphor-fan-presence/control/"]
+        },
+        {
+            "Path": "/var/lib/phosphor-post-code-manager/",
+            "Description": "Host progress codes persisted data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Periodic",
+            "Periodicity": "PT60S"
         }
     ]
 }


### PR DESCRIPTION
This commit adds '/var/lib/phosphor-post-code-manager/' to the sync configuration to ensure host POST code data is available on both BMC