### PR TITLE
config: Add sync config for PHAL persisted data

### DIFF
--- a/config/data_sync_list/open-power.json
+++ b/config/data_sync_list/open-power.json
@@ -19,6 +19,12 @@
             "Description": "Hardware isolation persisted data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/var/lib/phal/",
+            "Description": "PHAL persisted data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ]
 }


### PR DESCRIPTION
This commit adds '/var/lib/phal/' to the sync configuration to ensure PHAL-related state data is available on both BMCs

The directory is synced immediately from the active to the passive BMC