### PR TITLE
config: Add sync config for hardware isolation data

### DIFF
--- a/config/data_sync_list/open-power.json
+++ b/config/data_sync_list/open-power.json
@@ -13,6 +13,12 @@
             "Description": "BMC-OCC persisted data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/var/lib/op-hw-isolation/persistdata/",
+            "Description": "Hardware isolation persisted data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ]
 }


### PR DESCRIPTION
This commit adds '/var/lib/op-hw-isolation/persistdata/' to the sync configuration to ensure hardware isolation state is preserved across BMCs

The directory is synced immediately from the active to the passive BMC to maintain the data on both bmc
