### PR TITLE
Replace `std::system` with `posix_spawn` for async execution

### DIFF
--- a/src/async_command_exec.cpp
+++ b/src/async_command_exec.cpp
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "async_command_exec.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace data_sync::async
+{
+
+namespace utility
+{
+
+SpawnFActions::SpawnFActions()
+{
+    if (posix_spawn_file_actions_init(&_actions) != 0)
+    {
+        lg2::error("Failed to init posix_spawn_file_actions, errno : {ERRNO}, "
+                   "ERROR : {ERROR}",
+                   "ERRNO", errno, "ERROR", strerror(errno));
+        throw std::runtime_error("Failed to init posix_spawn_file_actions");
+    }
+}
+
+SpawnFActions::~SpawnFActions()
+{
+    if (posix_spawn_file_actions_destroy(&_actions) != 0)
+    {
+        lg2::error(
+            "Failed to destroy the file action instance, errno : {ERRNO}, "
+            "ERROR : {ERROR}",
+            "ERRNO", errno, "ERROR", strerror(errno));
+    }
+}
+
+posix_spawn_file_actions_t* SpawnFActions::get()
+{
+    return &_actions;
+}
+
+} // namespace utility
+
+AsyncCommandExecutor::AsyncCommandExecutor(sdbusplus::async::context& ctx) :
+    _ctx(ctx)
+{}
+
+bool AsyncCommandExecutor::setupPipe(int pipefd[2])
+{
+    if (pipe(pipefd) == -1)
+    {
+        lg2::error("Failed to create pipe. Errno: {ERRNO}, Error: {MSG}",
+                   "ERRNO", errno, "MSG", strerror(errno));
+        return false;
+    }
+    return true;
+}
+
+bool AsyncCommandExecutor::setupPipeRedirection(const FD& readFd,
+                                                const FD& writeFd,
+                                                const auto& actions)
+{
+    // Duplicate the write end of the pipe with the child's stdout and stderr
+    // so that the parent can read child stdout and stderr after the command
+    // execution is completed if any.
+    if (posix_spawn_file_actions_adddup2(actions, writeFd(), STDOUT_FILENO) !=
+            0 ||
+        posix_spawn_file_actions_adddup2(actions, writeFd(), STDERR_FILENO) !=
+            0)
+    {
+        lg2::error(
+            "Failed to duplicate the STDOUT/STDERR to pipe. Errno : {ERRNO}, Error : {MSG}",
+            "ERRNO", errno, "MSG", strerror(errno));
+        return false;
+    }
+
+    // Close the read end of the pipe in child before executing command because
+    // the parent only needs to read.
+    // Otherwise, kernel will think that the child is also reading and will be
+    // open even after parent closes it read end, which could cause blocking
+    // or close unused file descriptors in this child context.
+    if (posix_spawn_file_actions_addclose(actions, readFd()) != 0)
+    {
+        lg2::error("Failed to close the pipe's read end in child. Errno : "
+                   "{ERRNO}, Error : {MSG}",
+                   "ERRNO", errno, "MSG", strerror(errno));
+        return false;
+    }
+    return true;
+}
+
+std::pair<pid_t, int> AsyncCommandExecutor::spawnCommand(const std::string& cmd,
+                                                         const auto& actions)
+{
+    const char* argv[] = {"/bin/sh", "-c", cmd.c_str(), nullptr};
+    pid_t pid = -1;
+    int spawnResult = posix_spawn(
+        &pid, "/bin/sh", actions, nullptr,
+        // [cppcoreguidelines-pro-type-const-cast,-warnings-as-errors]
+        // NOLINTNEXTLINE
+        const_cast<char* const*>(argv), nullptr);
+
+    if (spawnResult != 0)
+    {
+        lg2::error("Spawn for executing command failed : {ERROR}", "ERROR",
+                   strerror(spawnResult));
+    }
+    return {pid, spawnResult};
+}
+
+sdbusplus::async::task<std::pair<int, std::string>>
+    // NOLINTNEXTLINE
+    AsyncCommandExecutor::execCmd(const std::string& cmd)
+{
+    int pipefd[2];
+    // Create pipe for the IPC
+    if (!setupPipe(pipefd))
+    {
+        co_return {-1, ""};
+    }
+
+    FD readFd(pipefd[0]);
+    FD writeFd(pipefd[1]);
+
+    utility::SpawnFActions fileActions;
+    auto* actions = fileActions.get();
+
+    if (!setupPipeRedirection(readFd, writeFd, actions))
+    {
+        co_return {-1, ""};
+    }
+
+    auto [pid, spawnResult] = spawnCommand(cmd, actions);
+
+    // Manually close the write end of the pipe in parent because only the child
+    // need to write.
+    // Otherwise, the kernel will think that the parent also writes and will be
+    // open even after child closes it's write end, which could blocks the
+    // parent's read() forever without returning EOF and will hang waiting to
+    // read.
+    writeFd.reset();
+
+    // Wait until the child writes into the fd.
+    auto output = co_await waitForCmdCompletion(readFd());
+
+    // Manually close the read fd of the parent immediately instead of keeping
+    // it open until RAII scope cleanup.
+    readFd.reset();
+
+    // Wait for child process to exit
+    int status = -1;
+    waitpid(pid, &status, 0);
+
+    int exitCode = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    if (!WIFEXITED(status))
+    {
+        lg2::error("Child exited abnormally. Status: {STATUS}", "STATUS",
+                   status);
+    }
+    else if (exitCode != 0)
+    {
+        lg2::error("Command failed with exitCode: {CODE}, Error: {ERROR}",
+                   "CODE", exitCode, "ERROR", output);
+    }
+
+    co_return {exitCode, output};
+}
+
+sdbusplus::async::task<std::string>
+    // NOLINTNEXTLINE
+    AsyncCommandExecutor::waitForCmdCompletion(int fd)
+{
+    // Set non-blocking mode for the file descriptor
+    int flags = fcntl(fd, F_GETFL, 0);
+    // NOLINTNEXTLINE - [cppcoreguidelines-pro-type-vararg,-warnings-as-errors]
+    if (flags == -1 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+    {
+        lg2::error(
+            "Failed to set non-blocking mode. Errno: {ERRNO}, Msg: {MSG}",
+            "ERRNO", errno, "MSG", strerror(errno));
+        co_return "";
+    }
+
+    std::string output;
+    std::array<char, 512> buffer{};
+    auto fdioInstance = std::make_unique<sdbusplus::async::fdio>(_ctx, fd);
+
+    while (!_ctx.stop_requested())
+    {
+        co_await fdioInstance->next();
+
+        auto bytes = read(fd, buffer.data(), buffer.size());
+        if (bytes > 0)
+        {
+            output.append(buffer.data(), bytes);
+            buffer.fill(0);
+        }
+        else if (bytes == 0)
+        {
+            // EOF
+            break;
+        }
+        else if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+            continue;
+        }
+        else
+        {
+            lg2::error("read failed on fd[{FD}] : [{ERROR}]", "FD", fd, "ERROR",
+                       strerror(errno));
+            break;
+        }
+    }
+
+    co_return output;
+}
+
+} // namespace data_sync::async

--- a/src/async_command_exec.hpp
+++ b/src/async_command_exec.hpp
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "utility.hpp"
+
+#include <fcntl.h>
+#include <spawn.h>
+
+#include <sdbusplus/async.hpp>
+
+namespace data_sync::async
+{
+
+using FD = data_sync::utility::FD;
+namespace utility
+{
+/**
+ * @class SpawnFActions
+ *
+ * @brief Class to handle the file operations object of the posix std
+ */
+class SpawnFActions
+{
+  public:
+    SpawnFActions(const SpawnFActions&) = delete;
+    SpawnFActions& operator=(const SpawnFActions&) = delete;
+    SpawnFActions(SpawnFActions&&) = delete;
+    SpawnFActions& operator=(SpawnFActions&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * To initialize the file action object for handling the spawned
+     * process
+     */
+    SpawnFActions();
+
+    /**
+     * @brief Destructor
+     *
+     * To destroy the file action object.
+     */
+    ~SpawnFActions();
+
+    /**
+     * @brief API to return the reference of the initialised file actions
+     * object
+     *
+     * @return posix_spawn_file_actions_t*
+     */
+    posix_spawn_file_actions_t* get();
+
+  private:
+    posix_spawn_file_actions_t _actions;
+};
+} // namespace utility
+
+/**
+ * @class AsyncCommandExecutor
+ *
+ * @brief To abstract the APIs to execute the CLI commands with posix spawn.
+ */
+class AsyncCommandExecutor
+{
+  public:
+    AsyncCommandExecutor(const AsyncCommandExecutor&) = delete;
+    AsyncCommandExecutor& operator=(const AsyncCommandExecutor&) = delete;
+    AsyncCommandExecutor(AsyncCommandExecutor&&) = delete;
+    AsyncCommandExecutor& operator=(AsyncCommandExecutor&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     *  @param[in] ctx - The async context object
+     *
+     */
+    AsyncCommandExecutor(sdbusplus::async::context& ctx);
+
+    /**
+     * @brief To execute bash commands asynchronously and redirect the
+     *        comamnd output to a pipe to read by parent process using
+     *        'posix_spawn'.
+     *
+     * @param[in] - cmd - The bash command to execute
+     *
+     * @return sdbusplus::async::task<std::pair<int, std::string>>
+     *              - int : Exit code of the spawned process (-1 on failure)
+     *              - std::string : Combined stdout and stderr output
+     */
+    sdbusplus::async::task<std::pair<int, std::string>>
+        execCmd(const std::string& cmd);
+
+  private:
+    /**
+     * @brief API to setup the pipe for the parent ot child communication by
+     * wrapping the pipe() system call.
+     *
+     * @param[out] pipefd - Array of two integers to hold the read and write end
+     *                      of the created pipe.
+     *
+     * @return - true, if the pipe was successfully created.
+     *         - false, if the pipe creation failed.
+     */
+    static bool setupPipe(int pipefd[2]);
+
+    /**
+     * @brief Configure file actions to redirect child process stdout and stderr
+     * to the write end of the pipe so that parent can read the same.
+     *
+     * @param[in]  readFd   File descriptor for the read end of the pipe.
+     * @param[in]  writeFd  File descriptor for the write end of the pipe.
+     * @param[in]  actions  reference to the posix_spawn file actions object.
+     *
+     * @return true,  if the redirections were successfully set up.
+     *         false, if any of the redirections failed.
+     */
+    bool setupPipeRedirection(const FD& readFd, const FD& writeFd,
+                              const auto& actions);
+
+    /**
+     * @brief API to spawn a child process by wrapping the posix_spawn(),
+     *        executing the provided command string in the spawned child
+     *        process.
+     *
+     * @param[in]  cmd     Command string to execute.
+     * @param[in]  actions  reference to the posix_spawn file actions object
+     *
+     * @return std::pair<pid_t, int>
+     *         - first  : PID of the spawned child process (-1 for failure).
+     *         - second : Result of posix_spawn().
+     */
+    std::pair<pid_t, int> spawnCommand(const std::string& cmd,
+                                       const auto& actions);
+
+    /**
+     * @brief API to wait asynchronously until child completes the command
+     *        execution and read and accumulate the output from the file
+     *        descriptor once it is ready.
+     *
+     * @param[in] - fd - file descriptor to read the data from.
+     *
+     * @return - sdbusplus::async::task<std::string>
+     *             On success - The accumulated output from the descriptor.
+     *             On failure - An empty string.
+     *
+     */
+    sdbusplus::async::task<std::string> waitForCmdCompletion(int fd);
+
+    /**
+     * @brief The async context object used to perform operations
+     *        asynchronously as required.
+     */
+    sdbusplus::async::context& _ctx;
+};
+} // namespace data_sync::async

--- a/src/data_watcher.hpp
+++ b/src/data_watcher.hpp
@@ -2,8 +2,9 @@
 
 #pragma once
 
+#include "utility.hpp"
+
 #include <sys/inotify.h>
-#include <unistd.h>
 
 #include <data_sync_config.hpp>
 #include <sdbusplus/async.hpp>
@@ -18,6 +19,7 @@ namespace data_sync::watch::inotify
 using DataSyncCfg = data_sync::config::DataSyncConfig;
 
 namespace fs = std::filesystem;
+namespace utility = data_sync::utility;
 
 /**
  * @brief A tuple which has the info related to the occured inotify event
@@ -54,42 +56,6 @@ enum class DataOps
  */
 using DataOperation = std::pair<fs::path, DataOps>;
 using DataOperations = std::vector<DataOperation>;
-
-/** @class FD
- *
- *  @brief RAII wrapper for file descriptor.
- */
-class FD
-{
-  public:
-    FD(const FD&) = delete;
-    FD& operator=(const FD&) = delete;
-    FD(FD&&) = delete;
-    FD& operator=(FD&&) = delete;
-
-    /** @brief Saves File descriptor and uses it to do file operation
-     *
-     *  @param[in] fd - File descriptor
-     */
-    explicit FD(int fd) : fd(fd) {}
-
-    ~FD()
-    {
-        if (fd >= 0)
-        {
-            close(fd);
-        }
-    }
-
-    int operator()() const
-    {
-        return fd;
-    }
-
-  private:
-    /** @brief File descriptor */
-    int fd = -1;
-};
 
 /** @class DataWatcher
  *
@@ -172,7 +138,7 @@ class DataWatcher
     /**
      * @brief file descriptor referring to the inotify instance
      */
-    FD _inotifyFileDescriptor;
+    utility::FD _inotifyFileDescriptor;
 
     /**
      * @brief fdio instance

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ nlohmann_json_dep = dependency('nlohmann_json')
 
 rbmc_data_sync_sources = [
     files(
+        'async_command_exec.cpp',
         'data_sync_config.cpp',
         'data_watcher.cpp',
         'external_data_ifaces.cpp',
@@ -14,6 +15,7 @@ rbmc_data_sync_sources = [
         'manager.cpp',
         'persistent.cpp',
         'sync_bmc_data_ifaces.cpp',
+        'utility.cpp',
     ),
 ]
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "utility.hpp"
+
+#include <unistd.h>
+namespace data_sync::utility
+{
+
+FD::FD(int fd) : fd(fd) {}
+
+FD::~FD()
+{
+    reset();
+}
+
+void FD::reset()
+{
+    if (fd >= 0)
+    {
+        close(fd);
+        fd = -1;
+    }
+}
+
+int FD::operator()() const
+{
+    return fd;
+}
+
+} // namespace data_sync::utility

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace data_sync::utility
+{
+
+/**
+ * @class FD
+ * @brief RAII wrapper for file descriptor.
+ */
+class FD
+{
+  public:
+    FD(const FD&) = delete;
+    FD& operator=(const FD&) = delete;
+    FD(FD&&) = delete;
+    FD& operator=(FD&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * Saves the file descriptor and uses it to do file operation
+     *
+     *  @param[in] fd - File descriptor
+     */
+    explicit FD(int fd);
+
+    /**
+     * @brief Destructor
+     *
+     * To close the file descriptor once goes out of scope.
+     */
+    ~FD();
+
+    /**
+     * @brief To close the file descriptor manually.
+     */
+    void reset();
+
+    /**
+     * @brief To return the saved file descriptor
+     */
+    int operator()() const;
+
+  private:
+    /**
+     * @brief File descriptor
+     */
+    int fd = -1;
+};
+
+} // namespace data_sync::utility

--- a/test/full_sync_test.cpp
+++ b/test/full_sync_test.cpp
@@ -6,6 +6,7 @@ namespace fs = std::filesystem;
 
 std::filesystem::path ManagerTest::dataSyncCfgDir;
 std::filesystem::path ManagerTest::tmpDataSyncDataDir;
+std::filesystem::path ManagerTest::destDir;
 
 using FullSyncStatus = sdbusplus::common::xyz::openbmc_project::control::
     SyncBMCData::FullSyncStatus;
@@ -49,34 +50,29 @@ TEST_F(ManagerTest, FullSyncA2PTest)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile1"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Active to Passive bmc"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile2"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Active to Passive bmc"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile3"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Active to Passive bmc"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile4"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Active to Passive bmc"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}}}},
 
         {"Directories",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcDir/"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Active to Passive bmc directory"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}}}}};
@@ -167,6 +163,11 @@ TEST_F(ManagerTest, FullSyncA2PTest)
         EXPECT_EQ(ManagerTest::readData(destsubDirFile),
                   "Data in source directory file");
 
+        // Wait to ensure the immediate and periodic sync tasks configured
+        // in the test setup are spawned. If the context is stopped while
+        // spawning is still in progress, the spawn will fail.
+        co_await sdbusplus::async::sleep_for(ctx,
+                                             std::chrono::milliseconds(50));
         ctx.request_stop();
 
         // Forcing to trigger inotify events so that all running immediate
@@ -223,33 +224,28 @@ TEST_F(ManagerTest, FullSyncP2ATest)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile1"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile2"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile3"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile4"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}}}},
         {"Directories",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcDir/"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "Parse test directory"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}}}}};
@@ -341,6 +337,11 @@ TEST_F(ManagerTest, FullSyncP2ATest)
         EXPECT_EQ(ManagerTest::readData(destsubDirFile),
                   "Data in source directory file");
 
+        // Wait to ensure the immediate and periodic sync tasks configured
+        // in the test setup are spawned. If the context is stopped while
+        // spawning is still in progress, the spawn will fail.
+        co_await sdbusplus::async::sleep_for(ctx,
+                                             std::chrono::milliseconds(50));
         ctx.request_stop();
 
         // Forcing to trigger inotify events so that all running immediate
@@ -395,33 +396,28 @@ TEST_F(ManagerTest, FullSyncInProgressTest)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile1"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile2"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile3"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile4"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}}}},
         {"Directories",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcDir/"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "Parse test directory"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}}}}};
@@ -491,6 +487,12 @@ TEST_F(ManagerTest, FullSyncInProgressTest)
 
         EXPECT_EQ(status, FullSyncStatus::FullSyncInProgress)
             << "FullSync status is not InProgress!";
+
+        // Wait to ensure the immediate and periodic sync tasks configured
+        // in the test setup are spawned. If the context is stopped while
+        // spawning is still in progress, the spawn will fail.
+        co_await sdbusplus::async::sleep_for(ctx,
+                                             std::chrono::milliseconds(50));
         ctx.request_stop();
 
         // Forcing to trigger inotify events so that all running immediate
@@ -546,20 +548,17 @@ TEST_F(ManagerTest, FullSyncFailed)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile1"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile2"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}},
           {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile3"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "FullSync from Passive to Active bmc"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Immediate"}},
@@ -644,6 +643,11 @@ TEST_F(ManagerTest, FullSyncFailed)
                   data3);
         EXPECT_FALSE(fs::exists(destDir4 / fs::relative(srcFile4, "/")));
 
+        // Wait to ensure the immediate and periodic sync tasks configured
+        // in the test setup are spawned. If the context is stopped while
+        // spawning is still in progress, the spawn will fail.
+        co_await sdbusplus::async::sleep_for(ctx,
+                                             std::chrono::milliseconds(50));
         ctx.request_stop();
 
         // Forcing to trigger inotify events so that all running immediate
@@ -777,6 +781,11 @@ TEST_F(ManagerTest, FullSyncA2PWithExcludeDirTest)
         EXPECT_EQ(ManagerTest::readData(destSubDir1File), dataSubDir1File);
         EXPECT_FALSE(fs::exists(destExcludeDirX));
 
+        // Wait to ensure the immediate and periodic sync tasks configured
+        // in the test setup are spawned. If the context is stopped while
+        // spawning is still in progress, the spawn will fail.
+        co_await sdbusplus::async::sleep_for(ctx,
+                                             std::chrono::milliseconds(50));
         ctx.request_stop();
 
         // Forcing to trigger inotify events so that all running immediate
@@ -901,6 +910,11 @@ TEST_F(ManagerTest, FullSyncA2PWithExcludeFileTest)
         EXPECT_EQ(ManagerTest::readData(destDirFile1), dataDirFile1);
         EXPECT_FALSE(fs::exists(destExcludeFile));
 
+        // Wait to ensure the immediate and periodic sync tasks configured
+        // in the test setup are spawned. If the context is stopped while
+        // spawning is still in progress, the spawn will fail.
+        co_await sdbusplus::async::sleep_for(ctx,
+                                             std::chrono::milliseconds(50));
         ctx.request_stop();
 
         // Forcing to trigger inotify events so that all running immediate

--- a/test/immediate_sync_test.cpp
+++ b/test/immediate_sync_test.cpp
@@ -11,6 +11,7 @@ namespace fs = std::filesystem;
 std::filesystem::path ManagerTest::dataSyncCfgDir;
 std::filesystem::path ManagerTest::tmpDataSyncDataDir;
 nlohmann::json ManagerTest::commonJsonData;
+std::filesystem::path ManagerTest::destDir;
 
 TEST_F(ManagerTest, testDataChangeInFile)
 {
@@ -41,8 +42,7 @@ TEST_F(ManagerTest, testDataChangeInFile)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "File to test immediate sync upon data write"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}}}}};
@@ -127,8 +127,7 @@ TEST_F(ManagerTest, testDataDeleteInDir)
     nlohmann::json jsonData = {
         {"Directories",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcDir/"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "Directory to test immediate sync on file deletion"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}}}}};
@@ -219,8 +218,7 @@ TEST_F(ManagerTest, testDataDeletePathFile)
         {"Files",
          {{{"Path",
             ManagerTest::tmpDataSyncDataDir.string() + "/srcDir/TestFile"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "File to test immediate sync on self delete"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}}}}};
@@ -315,8 +313,7 @@ TEST_F(ManagerTest, testDataChangeWhenSyncIsDisabled)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile2"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "File to test immediate sync when sync is disabled"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Immediate"}}}}};
@@ -412,8 +409,7 @@ TEST_F(ManagerTest, testDataCreateInSubDir)
     nlohmann::json jsonData = {
         {"Directories",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcDir/"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description",
             "File to test immediate sync on non existent dest path"},
            {"SyncDirection", "Active2Passive"},

--- a/test/manager_test.cpp
+++ b/test/manager_test.cpp
@@ -4,6 +4,7 @@
 std::filesystem::path ManagerTest::dataSyncCfgDir;
 std::filesystem::path ManagerTest::tmpDataSyncDataDir;
 nlohmann::json ManagerTest::commonJsonData;
+std::filesystem::path ManagerTest::destDir;
 
 namespace fs = std::filesystem;
 
@@ -111,14 +112,12 @@ TEST_F(ManagerTest, testDBusDataPersistency)
         {"Files",
          {
              {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile1"},
-              {"DestinationPath",
-               ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+              {"DestinationPath", ManagerTest::destDir.string()},
               {"Description", "FullSync from Active to Passive bmc"},
               {"SyncDirection", "Active2Passive"},
               {"SyncType", "Immediate"}},
              {{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile2"},
-              {"DestinationPath",
-               ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+              {"DestinationPath", ManagerTest::destDir.string()},
               {"Description", "FullSync from Active to Passive bmc"},
               {"SyncDirection", "Active2Passive"},
               {"SyncType", "Immediate"}},

--- a/test/manager_test.hpp
+++ b/test/manager_test.hpp
@@ -25,6 +25,14 @@ class ManagerTest : public ::testing::Test
     void SetUp() override
     {
         dataSyncCfgFile = dataSyncCfgDir / "testcase_config.json";
+        destDir = tmpDataSyncDataDir.string() + "/destDir/";
+
+        // The data-sync using rsync with --relative, it reconstructs
+        // the source path tree and attempts to create destination directory
+        // on every rsync. The first call succeeds, but subsequent calls may
+        // fail with "File exists (17)". To avoid this, ensure the destination
+        // directory is created beforehand, or use a different destination path.
+        std::filesystem::create_directories(destDir);
     }
 
     // Tear down each individual test
@@ -79,5 +87,6 @@ class ManagerTest : public ::testing::Test
     static std::filesystem::path dataSyncCfgDir;
     static nlohmann::json commonJsonData;
     static std::filesystem::path tmpDataSyncDataDir;
+    static std::filesystem::path destDir;
     std::filesystem::path dataSyncCfgFile;
 };

--- a/test/periodic_sync_test.cpp
+++ b/test/periodic_sync_test.cpp
@@ -5,6 +5,7 @@ namespace fs = std::filesystem;
 std::filesystem::path ManagerTest::dataSyncCfgDir;
 std::filesystem::path ManagerTest::tmpDataSyncDataDir;
 nlohmann::json ManagerTest::commonJsonData;
+std::filesystem::path ManagerTest::destDir;
 
 TEST_F(ManagerTest, PeriodicDataSyncTest)
 {
@@ -32,8 +33,7 @@ TEST_F(ManagerTest, PeriodicDataSyncTest)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile1"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "Parse test file"},
            {"SyncDirection", "Bidirectional"},
            {"SyncType", "Periodic"},
@@ -104,8 +104,7 @@ TEST_F(ManagerTest, PeriodicDataSyncDelayFileTest)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile1"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "Parse test file"},
            {"SyncDirection", "Bidirectional"},
            {"SyncType", "Periodic"},
@@ -176,8 +175,7 @@ TEST_F(ManagerTest, PeriodicDataSyncMultiRWTest)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile2"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "Parse test file"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Periodic"},
@@ -252,8 +250,7 @@ TEST_F(ManagerTest, PeriodicDataSyncP2ATest)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile3"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "Parse test file"},
            {"SyncDirection", "Passive2Active"},
            {"SyncType", "Periodic"},
@@ -316,8 +313,7 @@ TEST_F(ManagerTest, PeriodicDisablePropertyTest)
     nlohmann::json jsonData = {
         {"Files",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcFile2"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "Parse test file"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Periodic"},
@@ -389,8 +385,7 @@ TEST_F(ManagerTest, PeriodicDataSyncTestDataDeleteInDir)
     nlohmann::json jsonData = {
         {"Directories",
          {{{"Path", ManagerTest::tmpDataSyncDataDir.string() + "/srcDir/"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "Directory to test periodic sync on file deletion"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Periodic"},
@@ -472,8 +467,7 @@ TEST_F(ManagerTest, PeriodicDataSyncTestDataDeleteFile)
         {"Files",
          {{{"Path",
             ManagerTest::tmpDataSyncDataDir.string() + "/srcDir/TestFile"},
-           {"DestinationPath",
-            ManagerTest::tmpDataSyncDataDir.string() + "/destDir/"},
+           {"DestinationPath", ManagerTest::destDir.string()},
            {"Description", "Directory to test periodic sync on file deletion"},
            {"SyncDirection", "Active2Passive"},
            {"SyncType", "Periodic"},

--- a/test/persistent_data_test.cpp
+++ b/test/persistent_data_test.cpp
@@ -3,6 +3,7 @@
 
 std::filesystem::path ManagerTest::dataSyncCfgDir;
 std::filesystem::path ManagerTest::tmpDataSyncDataDir;
+std::filesystem::path ManagerTest::destDir;
 
 using FullSyncStatus = sdbusplus::common::xyz::openbmc_project::control::
     SyncBMCData::FullSyncStatus;


### PR DESCRIPTION
This commit introduces the changes to replace the `std::system` with `posix_spawn` for the execution of RSYNC CLI in order to achieve the asynchronous execution of multiple RSYNC commands.

Reasons for moving to posix_spawn():

 - The `std::system()` is a blocking call where it hold until the command finishes execution which is achieving asynchronous behavior.
 - `std::system()` lacks the method to capture the output of the execution to the parent/caller and the return value of the execution which results in limited error handling.
 - `posix_spawn` enables launching child processes without blocking the main thread.
 - `posix_spawn_file_actions` allows fine-grained control of fd redirection, useful for isolating command input/output.

Details of implementation:

 - The API `execCmd()` invokes `posix_spawn()` to execute the rsync command asynchronously.
 - Redirects child's stdout/stderr through a pipe to capture and process output at the parent.
 - Uses `posix_spawn_file_actions_t` to safely setup file descriptors.
 - The API `waitForCmdCompletion()` waits on the child process and reads output from the pipe.
 - The `execCmd()` finally returns the result code and output string to the caller.

Tested:
 - Verified the sync behavior on Huygens simics model during full sync and immediate sync.

Change-Id: I2f80f7806db62a022425df9e84a7edeb28d355e9