### PR TITLE
config: Add sync config for system LED data

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -35,6 +35,12 @@
             "SyncDirection": "Active2Passive",
             "SyncType": "Periodic",
             "Periodicity": "PT60S"
+        },
+        {
+            "Path": "/var/lib/phosphor-led-manager/",
+            "Description": "System LED persisted data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ]
 }


### PR DESCRIPTION
This commit adds '/var/lib/phosphor-led-manager/' to the sync configuration to ensure system LED state is preserved across BMC

The directory is synced immediately from the active to the passive BMC