### PR TITLE
config: Add sync config for host VMI data

### DIFF
--- a/config/data_sync_list/open-power.json
+++ b/config/data_sync_list/open-power.json
@@ -31,6 +31,12 @@
             "Description": "PHAL persisted data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/var/lib/network/hypervisor/",
+            "Description": "Hypervisor Network persisted configuration",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ]
 }


### PR DESCRIPTION
This commit adds '/var/lib/network/hypervisor/' to the sync configuration to ensure host virtual management interface (VMI) data is preserved across BMC

The directory is synced immediately from the active to the passive BMC to retain consistent network configuration state after a failover
