### PR TITLE
config: Add sync config for encrypted credential store data

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -41,6 +41,12 @@
             "Description": "System LED persisted data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/etc/credstore.encrypted/",
+            "Description": "Persisted credentials encrypted data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ]
 }


### PR DESCRIPTION
This commit adds '/etc/credstore.encrypted/' to the sync configuration to ensure encrypted credential data is preserved across BMC

The directory is synced immediately from the active to the passive
