### PR TITLE
config: Add sync config for ACF certificate data

### DIFF
--- a/config/data_sync_list/ibm.json
+++ b/config/data_sync_list/ibm.json
@@ -6,5 +6,13 @@
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
         }
+    ],
+    "Directories": [
+        {
+            "Path": "/etc/acf/",
+            "Description": "Persisted ACF certificates",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
+        }
     ]
 }


### PR DESCRIPTION
This commit adds '/etc/acf/' to the sync configuration to ensure persisted ACF certificate data is available on both BMC

The directory is synced immediately from the active to the passive BMC to retain certificate state across failovers
