### PR TITLE
config: Add sync config for host device tree data

### DIFF
--- a/config/data_sync_list/open-power.json
+++ b/config/data_sync_list/open-power.json
@@ -5,6 +5,12 @@
             "Description": "GUARD",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/var/lib/phosphor-software-manager/hostfw/running/DEVTREE",
+            "Description": "Host CEC persisted data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ],
     "Directories": [


### PR DESCRIPTION
This commit adds the DEVTREE file from '/var/lib/phosphor-software -manager/hostfw/running/' to the sync configuration to ensure host firmware hardware description data is preserved across BMC

The file is synced immediately from the active to the passive BMC