### PR TITLE
config: Add sync config for host owned VPD cache

### DIFF
--- a/config/data_sync_list/open-power.json
+++ b/config/data_sync_list/open-power.json
@@ -23,6 +23,12 @@
             "Description": "PHYP persisted NVRAM checksum data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/var/lib/phosphor-software-manager/hostfw/running/EECACHE",
+            "Description": "Host owned persisted VPD data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ],
     "Directories": [


### PR DESCRIPTION
This commit adds the EECACHE file from '/var/lib/phosphor- software-manager/hostfw/running/' to the sync configuration to ensure host owned VPD cache data is preserved across BMC

EECACHE is maintained by Hostboot and contains a cached view of the VPD EEPROM, Since this data is shared across both BMC, it must be kept in sync to ensure consistency regardless of which BMC is active
