### PR TITLE
config: Add sync config for host NVRAM data

### DIFF
--- a/config/data_sync_list/open-power.json
+++ b/config/data_sync_list/open-power.json
@@ -29,6 +29,12 @@
             "Description": "Host owned persisted VPD data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/var/lib/phosphor-software-manager/hostfw/running/NVRAM",
+            "Description": "Host OPAL persisted NVRAM data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ],
     "Directories": [


### PR DESCRIPTION
This commit adds the NVRAM file from '/var/lib/phosphor-software -manager/hostfw/running/' to the sync configuration to ensure host OPAL NVRAM data is preserved across BMC

This data is used by OPAL, particularly in manufacturing and must be kept in sync

The file is synced immediately from the active to the passive BMC
