### PR TITLE
config: Add sync config for PHYP NVRAM data

### DIFF
--- a/config/data_sync_list/open-power.json
+++ b/config/data_sync_list/open-power.json
@@ -11,6 +11,12 @@
             "Description": "Host CEC persisted data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM",
+            "Description": "PHYP persisted NVRAM data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ],
     "Directories": [


### PR DESCRIPTION
This commit adds the PHYP-NVRAM file from '/var/lib/phosphor- software-manager/hostfw/nvram/' to the sync configuration to ensure PHYP-specific NVRAM data is preserved across BMC

The file is synced immediately from the active to the passive BMC
