### PR TITLE
config: Add sync config for PHYP NVRAM checksum data

### DIFF
--- a/config/data_sync_list/open-power.json
+++ b/config/data_sync_list/open-power.json
@@ -17,6 +17,12 @@
             "Description": "PHYP persisted NVRAM data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM-CKSUM",
+            "Description": "PHYP persisted NVRAM checksum data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ],
     "Directories": [


### PR DESCRIPTION
This commit adds the PHYP-NVRAM-CKSUM file from '/var/lib/phosphor -software-manager/hostfw/nvram/' to the sync configuration to ensure the checksum data associated with PHYP NVRAM is preserved across BMC

The file is synced immediately from the active to the passive BMC

