### PR TITLE
config: Add sync config for system state manager data

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -17,10 +17,15 @@
     ],
     "Directories": [
         {
-            "Path": "/var/lib/phosphor-state-manager/host{}-PersistData/",
-            "Description": "Host State Persisted data",
+            "Path": "/var/lib/phosphor-state-manager/",
+            "Description": "System states persisted data",
             "SyncDirection": "Active2Passive",
-            "SyncType": "Immediate"
+            "SyncType": "Immediate",
+            "ExcludeList": [
+                "/var/lib/phosphor-state-manager/requestedHostTransition",
+                "/var/lib/phosphor-state-manager/POHCounter",
+                "/var/lib/phosphor-state-manager/chassisStateChangeTime"
+            ]
         },
         {
             "Path": "/var/lib/phosphor-fan-presence/",


### PR DESCRIPTION
This commit adds '/var/lib/phosphor-state-manager/' to the sync configuration to preserve system state information across BMC

The directory is synced immediately from the active to the passive The following files are excluded:
  • requestedHostTransition — no longer used
  • POHCounter — no longer used
  • chassisStateChangeTime — no longer used