### PR TITLE
config: Add sync config for system inventory data

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -50,6 +50,13 @@
             "ExcludeList": [
                 "/var/lib/phosphor-settings-manager/settings/xyz/openbmc_project/control/minimum_ship_level_required__"
             ]
+        },
+        {
+            "Path": "/var/lib/phosphor-inventory-manager/",
+            "Description": "System inventory persisted data (synced to backup dir on passive to avoid DBus exposure)",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate",
+            "DestinationPath": "/var/lib/phosphor-data-sync/bmc_data_bkp/"
         }
     ]
 }


### PR DESCRIPTION
This commit adds '/var/lib/phosphor-inventory-manager/' to the sync configuration to ensure system inventory data is preserved across BMC

The data is synced immediately from the active to the passive BMC to retain inventory state. However, the sync destination on the passive side is set to '/var/lib/phosphor-data-sync/bmc_data_bkp/' to avoid triggering inventory publication on DBus during passive BMC reboot
