### PR TITLE
config: Add sync config for PLDM persisted data

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -41,6 +41,16 @@
             "Description": "System LED persisted data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/var/lib/pldm/",
+            "Description": "PLDM persisted data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate",
+            "IncludeList": [
+                "/var/lib/pldm/pldm_store",
+                "/var/lib/pldm/license/"
+            ]
         }
     ]
 }


### PR DESCRIPTION
This commit adds '/var/lib/pldm/' to the sync configuration to ensure important PLDM state is preserved across BMC

syncing only selected paths '/var/lib/pldm/pldm_store/' and '/var/lib/pldm/license/'  using IncludeList, as these contain relevant persistent data, The sync is immediate from active to passive BMC
