### PR TITLE
config: Add sync config for host save area config files

### DIFF
--- a/config/data_sync_list/ibm.json
+++ b/config/data_sync_list/ibm.json
@@ -6,5 +6,13 @@
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
         }
+    ],
+    "Directories": [
+        {
+            "Path": "/var/lib/bmcweb/ibm-management-console/configfiles/",
+            "Description": "Host save area persisted data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
+        }
     ]
 }


### PR DESCRIPTION
This commit add '/var/lib/bmcweb/ibm-management-console/configfiles/' to the sync configuration to ensure host-side saved config data is preserved across BMC

The directory is synced immediately from active to passive
