### PR TITLE
config: Add sync config for settings manager data

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -41,6 +41,15 @@
             "Description": "System LED persisted data",
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate"
+        },
+        {
+            "Path": "/var/lib/phosphor-settings-manager/settings/",
+            "Description": "Persisted settings data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate",
+            "ExcludeList": [
+                "/var/lib/phosphor-settings-manager/settings/xyz/openbmc_project/control/minimum_ship_level_required__"
+            ]
         }
     ]
 }


### PR DESCRIPTION
This commit adds '/var/lib/phosphor-settings-manager/settings/' to the sync configuration to preserve system settings across BMC

The data is synced immediately from active to passive BMC. The file 'minimum_ship_level_required__' is excluded from sync
