### PR TITLE
config: Add sync config for service manager data

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -57,6 +57,12 @@
             "SyncDirection": "Active2Passive",
             "SyncType": "Immediate",
             "DestinationPath": "/var/lib/phosphor-data-sync/bmc_data_bkp/"
+        },
+        {
+            "Path": "/var/lib/service-config-manager/",
+            "Description": "Persisted service enable/disable config data",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Immediate"
         }
     ]
 }


### PR DESCRIPTION
Added '/var/lib/service-config-manager/' to the sync list to make sure service enable/disable state is preserved across BMC
The data is synced immediately from active to passive BMC