### PR TITLE
config : Move from /etc to /usr/share

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -71,10 +71,10 @@ BMC1_IP
   in the rsync CLI.
 
 ```sh
-/etc/phosphor-data-sync/rsync/bmc0_rsyncd.conf
-/etc/phosphor-data-sync/rsync/bmc1_rsyncd.conf
-/etc/phosphor-data-sync/stunnel/bmc0_stunnel.conf
-/etc/phosphor-data-sync/stunnel/bmc1_stunnel.conf
+/usr/share/phosphor-data-sync/config/rsync/bmc0_rsyncd.conf
+/usr/share/phosphor-data-sync/config/rsync/bmc1_rsyncd.conf
+/usr/share/phosphor-data-sync/config/stunnel/bmc0_stunnel.conf
+/usr/share/phosphor-data-sync/config/stunnel/bmc1_stunnel.conf
 ```
 
 - These generated configuration file will be picked as per the local BMC's

--- a/config/meson.build
+++ b/config/meson.build
@@ -9,7 +9,7 @@ foreach json_file_name : get_option('data_sync_list')
 
 endforeach
 
-etc_dir = get_option('sysconfdir') + '/phosphor-data-sync/'
+share_dir = get_option('datadir') + '/phosphor-data-sync/'
 
 # Process rsync and stunnel configuration templates to substitute fields
 # defined by Meson
@@ -47,9 +47,9 @@ custom_target(
 )
 
 # Install generated rsync and stunnel configuration files
-install_subdir(gen_cfg_files_path, install_dir: etc_dir, strip_directory: true)
+install_subdir(gen_cfg_files_path, install_dir: share_dir, strip_directory: true)
 install_data(
     'rsync/rsyncd_bmc_fs.filter',
-    install_dir: etc_dir,
+    install_dir: join_paths(share_dir, 'config'),
     preserve_path: true,
 )

--- a/config/rsync/rsyncd.conf.in
+++ b/config/rsync/rsyncd.conf.in
@@ -9,4 +9,4 @@ log file = /dev/null
     read only = false
     uid = root
     gid = root
-    filter = merge /etc/phosphor-data-sync/rsync/rsyncd_bmc_fs.filter
+    filter = merge /usr/share/phosphor-data-sync/config/rsync/rsyncd_bmc_fs.filter

--- a/scripts/gen_rsync_stunnel_cfg.sh
+++ b/scripts/gen_rsync_stunnel_cfg.sh
@@ -20,9 +20,9 @@ shift 3 # Sync socket configuration files base name and $@ will be used in below
 RSYNC_TEMPLATE="$IN_CFG_DIR/rsyncd.conf.in"
 STUNNEL_TEMPLATE="$IN_CFG_DIR/stunnel.conf.in"
 
-CERT_DIR="/etc/phosphor-data-sync/certs"
-RSYNC_OUT_DIR="$OUT_CFG_DIR/rsync"
-STUNNEL_OUT_DIR="$OUT_CFG_DIR/stunnel"
+CERT_DIR="/usr/share/phosphor-data-sync/certs"
+RSYNC_OUT_DIR="$OUT_CFG_DIR/config/rsync"
+STUNNEL_OUT_DIR="$OUT_CFG_DIR/config/stunnel"
 
 # Check template files exist
 for f in "$RSYNC_TEMPLATE" "$STUNNEL_TEMPLATE"; do

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -7,5 +7,5 @@ generated_certs = custom_target(
     command: [files('gen_certs.sh'), meson.current_build_dir()],
     build_by_default: true,
     install: true,
-    install_dir: join_paths(etc_dir, 'certs'),
+    install_dir: join_paths(share_dir, 'certs'),
 )

--- a/service_files/SyncBMCData_rsync.service
+++ b/service_files/SyncBMCData_rsync.service
@@ -6,7 +6,7 @@ After=SyncBMCData_stunnel.service
 [Service]
 ExecStart=/usr/bin/sh -c '\
 if [ -f /run/openbmc/bmc_position ]; then \
-    exec /usr/bin/rsync --no-detach --daemon --config=/etc/phosphor-data-sync/rsync/bmc$(cat /run/openbmc/bmc_position)_rsyncd.conf; \
+    exec /usr/bin/rsync --no-detach --daemon --config=/usr/share/phosphor-data-sync/config/rsync/bmc$(cat /run/openbmc/bmc_position)_rsyncd.conf; \
 else \
     echo "Failed to get the BMC position, /run/openbmc/bmc_position not found" >&2; \
     exit 1; \

--- a/service_files/SyncBMCData_stunnel.service
+++ b/service_files/SyncBMCData_stunnel.service
@@ -5,7 +5,7 @@ PartOf=SyncBMCData_rsync.service
 [Service]
 ExecStart=/usr/bin/sh -c '\
 if [ -f /run/openbmc/bmc_position ]; then \
-    exec /usr/bin/stunnel /etc/phosphor-data-sync/stunnel/bmc$(cat /run/openbmc/bmc_position)_stunnel.conf; \
+    exec /usr/bin/stunnel /usr/share/phosphor-data-sync/config/stunnel/bmc$(cat /run/openbmc/bmc_position)_stunnel.conf; \
 else \
     echo "Failed to get the BMC position, /run/openbmc/bmc_position not found" >&2; \
     exit 1; \


### PR DESCRIPTION
This commit moves the certificates, rsync, and stunnel configuration from `/etc/phosphor-data-sync` to `/usr/share/phosphor-data-sync`.

In OpenBMC, files under /etc persist the runtime modifications  across code updates due to the overlay filesystem on /var. The configurations in phosphor-data-sync are generated at build time and are not intended to retain user modifications. Keeping them under /etc risks stale or inconsistent configurations after updates.

Hence moving these files to `/usr/share` to ensure that each code update deploys the expected, validated configuration set without being affected by runtime changes.

Tested :

Verified that all the configs are getting installed into /usr/share path instead of /etc/ and phosphor-data-sync is working as expected.

New directory structure:

```
root@rbmc-prototype:~# ls -R /usr/share/phosphor-data-sync/
/usr/share/phosphor-data-sync/:
certs   config

/usr/share/phosphor-data-sync/certs:
bmc0.crt  bmc0.key  bmc1.crt  bmc1.key  ca.crt

/usr/share/phosphor-data-sync/config:
data_sync_list  rsync           stunnel

/usr/share/phosphor-data-sync/config/data_sync_list:
common.json      ibm.json         open-power.json

/usr/share/phosphor-data-sync/config/rsync:
bmc0_rsyncd.conf      bmc1_rsyncd.conf      rsyncd_bmc_fs.filter

/usr/share/phosphor-data-sync/config/stunnel:
bmc0_stunnel.conf  bmc1_stunnel.conf

```
Change-Id: Iefafd1e4bfd047a076c0727047ef92be713beae5