### PR TITLE
Fix stale watch descriptors and parent watch handling

### DIFF
--- a/src/data_watcher.cpp
+++ b/src/data_watcher.cpp
@@ -423,10 +423,17 @@ std::optional<std::vector<EventInfo>> DataWatcher::readEvents()
         // NOLINTNEXTLINE to avoid cppcoreguidelines-pro-type-reinterpret-cast
         auto* receivedEvent = reinterpret_cast<inotify_event*>(&buffer[offset]);
 
+        // Using find() because,
+        // IN_IGNORED events can arrive for already removed watch descriptors
+        // Hence use of [] to access the map entries will cause stale entries.
+        auto wdIter = _watchDescriptors.find(receivedEvent->wd);
+        std::string pathStr = (wdIter != _watchDescriptors.end())
+                                  ? wdIter->second.string()
+                                  : "[removed path]";
+
         lg2::debug("Received {EVENTS} from {PATH}, wd:{WD} and name : {NAME}",
-                   "EVENTS", eventName(receivedEvent->mask), "PATH",
-                   _watchDescriptors[receivedEvent->wd], "WD",
-                   receivedEvent->wd, "NAME", receivedEvent->name);
+                   "EVENTS", eventName(receivedEvent->mask), "PATH", pathStr,
+                   "WD", receivedEvent->wd, "NAME", receivedEvent->name);
 
         if (((receivedEvent->mask & _eventMasksToWatch) != 0) ||
             ((receivedEvent->mask & _eventMasksIfNotExists) != 0))
@@ -776,16 +783,21 @@ std::optional<DataOperation>
         _watchDescriptors.at(std::get<WD>(receivedEventInfo));
     lg2::debug("Processing IN_DELETE_SELF for {PATH}", "PATH", deletedPath);
 
-    if (_watchDescriptors.size() == 1)
-    {
-        // If configured file / directory got deleted add a watch on parent
-        // dir to notify future create events.
+    // Check if the configured path is same as or a child of the deleted path.
+    bool isConfiguredPathOrParent = _dataPathToWatch.string().starts_with(
+        (fs::is_directory(deletedPath) ? deletedPath / "" : deletedPath)
+            .string());
 
-        // Unique watches are there for all the sub directories also. Hence when
-        // a configured and monitoring directory deletes, IN_DELETE_SELF will
-        // emit for all sub directories which will remove its watches and
-        // finally will get IN_DELETE_SELF for the configured dir also which
-        // makes the size of _watchDescriptors 1.
+    if (isConfiguredPathOrParent)
+    {
+        // Add watch on parent dir to notify future create events when:
+        // 1. The configured path itself got deleted
+        // 2. A parent/ancestor of the configured path got deleted (when
+        //    configured path doesn't exist and we're watching its parent)
+        //
+        // Note: If a child of the configured path is deleted, this condition
+        // will be false, so we won't add a parent watch since the configured
+        // path or its parent is already being watched.
 
         auto parentPath = getExistingParentPath(deletedPath);
         if (parentPath.empty())

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -521,8 +521,9 @@ sdbusplus::async::task<bool>
     data_sync::async::AsyncCommandExecutor executor(_ctx);
     // NOLINTNEXTLINE
     auto result = co_await executor.execCmd(syncCmd);
-    lg2::debug("Rsync cmd return code : {RET} : output : {OUTPUT}", "RET",
-               result.first, "OUTPUT", result.second);
+    lg2::debug(
+        "Rsync cmd output for [{PATH}] : return code : {RET} : output : {OUTPUT}",
+        "PATH", currentSrcPath, "RET", result.first, "OUTPUT", result.second);
 
     ext_data::AdditionalData additionalDetails = {
         {"BMC_Role", _extDataIfaces->bmcRoleInStr()},


### PR DESCRIPTION
Issue observed:
Sometimes deletion of the configured path does not add a watch for the parent.

Root cause analysis:
When the configured path is created, a watch is added for it and the parent watch is removed from _watchDescriptors.  Once removed, the kernel emits an IN_IGNORED event for that watch descriptor.

During event logging, the code accesses
_watchDescriptors[receivedEvent->wd], which unintentionally recreates the removed watch descriptor with an empty path, leading to stale entries in the map that are never cleaned up.

These stale entriesinflate _watchDescriptors.size(), causing the size-based check in delete handling to fail. As a result, the parent watch is not re-added when the configured path is deleted.

Fix Proposed:
- Avoid stale entries in _watchDescriptors by using find() instead of [] during event handling, preventing creation of empty entries for IN_IGNORED descriptors.

- Replace unreliable _watchDescriptors.size() check in processDeleteSelf() with a direct check to determine if the deleted path is the configured path or its parent.

Note : This commit updated a logging trace also to print the rsync src path along with rsync stat output for better readability.

Tested:
Verified in rbmc-prototype card that watches are getting added to parent paths as expected and no stale entries in the watchDescriptors map.

Change-Id: I12d41d269555a6befe8449f1e047567be3642ce8