### PR TITLE
config: Add sync config for phosphor-logging

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -76,6 +76,13 @@
                 "Method": "Reload",
                 "NotifyServices": ["srvcfg-manager.service"]
             }
+        },
+        {
+            "Path": "/var/lib/phosphor-logging/",
+            "Description": "Phosphor logging persisted data",
+            "SyncDirection": "Bidirectional",
+            "SyncType": "Immediate",
+            "ExcludeList": ["/var/lib/phosphor-logging/extensions/pels/pelID"]
         }
     ]
 }


### PR DESCRIPTION
- Add /var/lib/phosphor-logging/ to the data sync configuration   so phosphor-logging persisted data is synchronized between   redundant BMCs.

- Use bidirectional immediate sync because logs and PELs may be   created on either BMC, and the peer should receive those updates   without waiting for a periodic sync.

- Exclude the PEL ID tracking file since it is locally managed and   syncing it could cause incorrect ID state across BMCs.

Tested:
- Verified phosphor-logging files are synced between BMCs
- Verified the PEL ID tracking file is excluded from sync

Change-Id: Icda36939d50225ff96635577a523af6b342cd9dc