### PR TITLE
Data sync tool : Add config related options

### DIFF
--- a/src/datasynctool/config_options.cpp
+++ b/src/datasynctool/config_options.cpp
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "config.h"
+
+#include "config_options.hpp"
+
+#include "dbus_interactions.hpp"
+#include "utils.hpp"
+
+#include <nlohmann/json.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/client.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <print>
+#include <string>
+#include <vector>
+
+namespace datasynctool::config_options
+{
+
+using json = nlohmann::ordered_json;
+
+namespace fs = std::filesystem;
+
+// Helper: Check if path should be included based on role and sync direction
+static bool shouldIncludePath(const std::string& syncDir,
+                              const std::string& role)
+{
+    if (role == "Active")
+    {
+        return (syncDir == "Active2Passive" || syncDir == "Bidirectional");
+    }
+    else if (role == "Passive")
+    {
+        return (syncDir == "Passive2Active" || syncDir == "Bidirectional");
+    }
+    return false;
+}
+
+// Helper: Process all entries in a JSON array
+static json processEntries(const json& entries, const std::string& role)
+{
+    json result = json::array();
+    for (const auto& entry : entries)
+    {
+        if (!entry.contains("SyncDirection") || !entry.contains("Path"))
+        {
+            continue;
+        }
+
+        if (!shouldIncludePath(entry["SyncDirection"], role))
+        {
+            continue;
+        }
+
+        json item;
+        item["Path"] = entry["Path"];
+
+        if (entry.contains("ExcludeList"))
+        {
+            item["ExcludeList"] = entry["ExcludeList"];
+        }
+        if (entry.contains("IncludeList"))
+        {
+            item["IncludeList"] = entry["IncludeList"];
+        }
+
+        if (!item.is_null())
+        {
+            result.push_back(item);
+        }
+    }
+    return result;
+}
+
+// Helper: Parse a single config file
+static void parseConfigFile(const fs::path& filePath, const std::string& role,
+                            json& files, json& directories)
+{
+    try
+    {
+        std::ifstream configFile(filePath);
+        if (!configFile.is_open())
+        {
+            std::cerr << "Failed to open: " << filePath << "\n";
+            return;
+        }
+
+        json config = json::parse(configFile);
+
+        if (config.contains("Files") && config["Files"].is_array())
+        {
+            auto processed = processEntries(config["Files"], role);
+            files.insert(files.end(), processed.begin(), processed.end());
+        }
+
+        if (config.contains("Directories") && config["Directories"].is_array())
+        {
+            auto processed = processEntries(config["Directories"], role);
+            directories.insert(directories.end(), processed.begin(),
+                               processed.end());
+        }
+    }
+    catch (const json::exception& e)
+    {
+        std::cerr << "JSON parse error in " << filePath << ": " << e.what()
+                  << "\n";
+    }
+}
+
+sdbusplus::async::task<> listConfigPaths(sdbusplus::async::context& ctx,
+                                         bool jsonOutput)
+{
+    try
+    {
+        auto role = co_await dbus_interactions::getBMCRole(ctx);
+        const fs::path configDir = DATA_SYNC_CONFIG_DIR;
+
+        if (!fs::exists(configDir) || !fs::is_directory(configDir))
+        {
+            std::cerr << "Config directory not found: " << configDir << "\n";
+            co_return;
+        }
+
+        json files = json::array();
+        json directories = json::array();
+
+        // Parse all JSON config files
+        for (const auto& entry : fs::directory_iterator(configDir))
+        {
+            if (entry.is_regular_file() && entry.path().extension() == ".json")
+            {
+                parseConfigFile(entry.path(), role, files, directories);
+            }
+        }
+
+        // Build and display output
+        json output;
+        output["Files"] = files;
+        output["Directories"] = directories;
+
+        if (jsonOutput)
+        {
+            std::println("{}", output.dump(4));
+        }
+        else
+        {
+            utils::displayJsonAsText(output);
+        }
+
+        co_return;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error listing config paths: " << e.what() << "\n";
+        throw;
+    }
+}
+
+} // namespace datasynctool::config_options

--- a/src/datasynctool/config_options.cpp
+++ b/src/datasynctool/config_options.cpp
@@ -13,6 +13,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <print>
 #include <string>
 #include <vector>
@@ -115,6 +116,7 @@ sdbusplus::async::task<> listConfigPaths(sdbusplus::async::context& ctx,
 {
     try
     {
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
         auto role = co_await dbus_interactions::getBMCRole(ctx);
         const fs::path configDir = DATA_SYNC_CONFIG_DIR;
 
@@ -155,6 +157,135 @@ sdbusplus::async::task<> listConfigPaths(sdbusplus::async::context& ctx,
     catch (const std::exception& e)
     {
         std::cerr << "Error listing config paths: " << e.what() << "\n";
+        throw;
+    }
+}
+
+// Helper function to search for a path (exact or parent) in a JSON array
+static std::optional<json> findPathInArray(const json& array,
+                                           const std::string& normalizedTarget)
+{
+    if (!array.is_array())
+    {
+        return std::nullopt;
+    }
+
+    for (const auto& jsonEntry : array)
+    {
+        if (jsonEntry.contains("Path"))
+        {
+            std::string configPath = jsonEntry["Path"].get<std::string>();
+            std::string normalizedConfig = utils::normalizePath(configPath);
+
+            // Check exact match OR if target is child of config directory
+            // (target starts with config path means it's a child)
+            if (normalizedTarget == normalizedConfig ||
+                normalizedTarget.find(normalizedConfig) == 0)
+            {
+                return jsonEntry;
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+sdbusplus::async::task<> getPathConfig(sdbusplus::async::context& ctx,
+                                       const std::string& targetPath,
+                                       bool jsonOutput)
+{
+    namespace fs = std::filesystem;
+
+    try
+    {
+        // False positive from clang static analyzer with coroutine
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
+        auto role = co_await dbus_interactions::getBMCRole(ctx);
+
+        const fs::path configDir = DATA_SYNC_CONFIG_DIR;
+
+        if (!fs::exists(configDir) || !fs::is_directory(configDir))
+        {
+            std::cerr << "Config directory not found: " << configDir << "\n";
+            co_return;
+        }
+
+        // Normalize target path once
+        std::string normalizedTarget = utils::normalizePath(targetPath);
+
+        // Search through all JSON config files
+        for (const auto& entry : fs::directory_iterator(configDir))
+        {
+            if (!entry.is_regular_file() || entry.path().extension() != ".json")
+            {
+                continue;
+            }
+
+            std::ifstream configFile(entry.path());
+            if (!configFile.is_open())
+            {
+                std::cerr << "Failed to open: " << entry.path() << "\n";
+                continue;
+            }
+
+            try
+            {
+                json config = json::parse(configFile);
+
+                auto matchedConfig = findPathInArray(config["Files"],
+                                                     normalizedTarget);
+                if (!matchedConfig)
+                {
+                    matchedConfig = findPathInArray(config["Directories"],
+                                                    normalizedTarget);
+                }
+
+                if (matchedConfig)
+                {
+                    // Add default retry values if not present
+                    if (!matchedConfig->contains("RetryAttempts"))
+                    {
+                        (*matchedConfig)["RetryAttempts"] =
+                            DEFAULT_RETRY_ATTEMPTS;
+                    }
+                    if (!matchedConfig->contains("RetryInterval"))
+                    {
+                        (*matchedConfig)["RetryInterval"] =
+                            std::to_string(DEFAULT_RETRY_INTERVAL) + " seconds";
+                    }
+
+                    // Add BMC Role to output
+                    (*matchedConfig)["BMC Role"] = role;
+
+                    // Append config file name
+                    (*matchedConfig)["Config File"] = entry.path().string();
+
+                    // Output the configuration
+                    if (jsonOutput)
+                    {
+                        std::println("{}", matchedConfig->dump(4));
+                    }
+                    else
+                    {
+                        utils::displayJsonAsText(*matchedConfig);
+                    }
+                    co_return;
+                }
+            }
+            catch (const json::exception& e)
+            {
+                std::cerr << "JSON parse error in " << entry.path() << ": "
+                          << e.what() << "\n";
+                continue;
+            }
+        }
+
+        std::cerr << "Error: Path '" << targetPath
+                  << "' not found in configuration\n";
+        co_return;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error getting path config: " << e.what() << "\n";
         throw;
     }
 }

--- a/src/datasynctool/config_options.hpp
+++ b/src/datasynctool/config_options.hpp
@@ -4,6 +4,8 @@
 
 #include <sdbusplus/async.hpp>
 
+#include <string>
+
 namespace datasynctool::config_options
 {
 
@@ -17,5 +19,18 @@ namespace datasynctool::config_options
  */
 sdbusplus::async::task<> listConfigPaths(sdbusplus::async::context& ctx,
                                          bool jsonOutput);
+
+/**
+ * @brief Get configuration for a specific path
+ *
+ * @param[in] ctx - Async context
+ * @param[in] targetPath - Path to get configuration for
+ * @param[in] jsonOutput - Output in JSON format if true
+ *
+ * @return async task
+ */
+sdbusplus::async::task<> getPathConfig(sdbusplus::async::context& ctx,
+                                       const std::string& targetPath,
+                                       bool jsonOutput);
 
 } // namespace datasynctool::config_options

--- a/src/datasynctool/config_options.hpp
+++ b/src/datasynctool/config_options.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <sdbusplus/async.hpp>
+
+namespace datasynctool::config_options
+{
+
+/**
+ * @brief List config paths filtered by BMC role and sync direction
+ *
+ * @param[in] ctx - Async context
+ * @param[in] jsonOutput - Output in JSON format if true
+ *
+ * @return async task
+ */
+sdbusplus::async::task<> listConfigPaths(sdbusplus::async::context& ctx,
+                                         bool jsonOutput);
+
+} // namespace datasynctool::config_options

--- a/src/datasynctool/dbus_interactions.cpp
+++ b/src/datasynctool/dbus_interactions.cpp
@@ -21,6 +21,28 @@ namespace datasynctool::dbus_interactions
 using SyncBMCData =
     sdbusplus::common::xyz::openbmc_project::control::SyncBMCData;
 
+sdbusplus::async::task<std::string> getBMCRole(sdbusplus::async::context& ctx)
+{
+    try
+    {
+        using RedundancyMgr =
+            sdbusplus::client::xyz::openbmc_project::state::bmc::Redundancy<>;
+
+        auto role = co_await RedundancyMgr(ctx)
+                        .service("xyz.openbmc_project.State.BMC.Redundancy")
+                        .path("/xyz/openbmc_project/state/bmc0")
+                        .role();
+
+        co_return utils::extractEnumValue(
+            RedundancyMgr::convertRoleToString(role));
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error getting BMC role: " << e.what() << "\n";
+        throw;
+    }
+}
+
 sdbusplus::async::task<> displayStatus(sdbusplus::async::context& ctx,
                                        bool jsonOutput)
 {

--- a/src/datasynctool/dbus_interactions.hpp
+++ b/src/datasynctool/dbus_interactions.hpp
@@ -17,18 +17,13 @@ using DbusVariant = std::variant<bool, std::string>;
 using PropertyMap = std::map<std::string, DbusVariant>;
 
 /**
- * @brief Get all D-Bus properties using GetAll method
+ * @brief Get BMC role from D-Bus
  *
- * @param[in] bus - D-Bus connection
- * @param[in] service - D-Bus service name
- * @param[in] path - D-Bus object path
- * @param[in] interface - D-Bus interface name
+ * @param[in] ctx - Async context
  *
- * @return PropertyMap - Map of property names to values
+ * @return BMC role string
  */
-PropertyMap getAllProperties(sdbusplus::bus_t& bus, const std::string& service,
-                             const std::string& path,
-                             const std::string& interface);
+sdbusplus::async::task<std::string> getBMCRole(sdbusplus::async::context& ctx);
 
 /**
  * @brief Build JSON object from D-Bus properties
@@ -40,7 +35,7 @@ PropertyMap getAllProperties(sdbusplus::bus_t& bus, const std::string& service,
 json buildStatusJson(const PropertyMap& properties);
 
 /**
- * @brief Display D-Bus status properties (async version)
+ * @brief Display D-Bus status properties
  *
  * @param[in] ctx - Async context
  * @param[in] jsonOutput - Output in JSON format if true
@@ -51,7 +46,7 @@ sdbusplus::async::task<> displayStatus(sdbusplus::async::context& ctx,
                                        bool jsonOutput);
 
 /**
- * @brief Start full sync operation (async version)
+ * @brief Start full sync operation
  *
  * @param[in] ctx - Async context
  *
@@ -60,7 +55,7 @@ sdbusplus::async::task<> displayStatus(sdbusplus::async::context& ctx,
 sdbusplus::async::task<> startFullSync(sdbusplus::async::context& ctx);
 
 /**
- * @brief Set sync enabled/disabled state (async version)
+ * @brief Set sync enabled/disabled state
  *
  * @param[in] ctx - Async context
  * @param[in] enable - true to enable sync, false to disable

--- a/src/datasynctool/main.cpp
+++ b/src/datasynctool/main.cpp
@@ -48,6 +48,13 @@ int main(int argc, char* argv[])
     configGroup->add_flag("-l,--listConfigPaths", showConfigPaths,
                           "List all configured paths for syncing");
 
+    std::string getConfPath;
+    configGroup
+        ->add_option("-g,--getSyncCfg", getConfPath,
+                     "Get data-sync configuration for a specific path")
+        ->type_name("AbsoluteDataPath")
+        ->check(CLI::ExistingPath);
+
     // Parse command line arguments
     if (argc == 1)
     {
@@ -73,6 +80,12 @@ int main(int argc, char* argv[])
     {
         ctx.spawn(
             datasynctool::config_options::listConfigPaths(ctx, jsonOutput));
+    }
+
+    if (!getConfPath.empty())
+    {
+        ctx.spawn(datasynctool::config_options::getPathConfig(ctx, getConfPath,
+                                                              jsonOutput));
     }
 
     if (showStatus)

--- a/src/datasynctool/main.cpp
+++ b/src/datasynctool/main.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "config_options.hpp"
 #include "dbus_interactions.hpp"
 
 #include <CLI/CLI.hpp>
@@ -40,6 +41,13 @@ int main(int argc, char* argv[])
 
     enableOpt->excludes(disableOpt);
 
+    auto* configGroup = app.add_option_group("Config options",
+                                             "Configuration related options");
+
+    bool showConfigPaths{false};
+    configGroup->add_flag("-l,--listConfigPaths", showConfigPaths,
+                          "List all configured paths for syncing");
+
     // Parse command line arguments
     if (argc == 1)
     {
@@ -59,6 +67,12 @@ int main(int argc, char* argv[])
     if (disableSync)
     {
         ctx.spawn(datasynctool::dbus_interactions::setSyncEnabled(ctx, false));
+    }
+
+    if (showConfigPaths)
+    {
+        ctx.spawn(
+            datasynctool::config_options::listConfigPaths(ctx, jsonOutput));
     }
 
     if (showStatus)

--- a/src/datasynctool/meson.build
+++ b/src/datasynctool/meson.build
@@ -5,10 +5,16 @@ cli11_dep = dependency('CLI11')
 
 # Build datasynctool executable
 
-datasynctool_sources = files('dbus_interactions.cpp', 'main.cpp', 'utils.cpp')
+datasynctool_sources = files(
+    'config_options.cpp',
+    'dbus_interactions.cpp',
+    'main.cpp',
+    'utils.cpp',
+)
 
 datasynctool_dependencies = [
     cli11_dep,
+    conf_h_dep,
     sdbusplus_dep,
     phosphor_dbus_interfaces_dep,
     phosphor_logging_dep,

--- a/src/datasynctool/utils.cpp
+++ b/src/datasynctool/utils.cpp
@@ -17,6 +17,23 @@ std::string extractEnumValue(const std::string& dbusValue)
     return dbusValue;
 }
 
+std::string normalizePath(const std::string& path)
+{
+    if (path.empty() || path == "/")
+    {
+        return path;
+    }
+
+    // Remove trailing slashes
+    std::string normalized = path;
+    while (normalized.length() > 1 && normalized.back() == '/')
+    {
+        normalized.pop_back();
+    }
+
+    return normalized;
+}
+
 template <typename T>
 void printParam(std::string key, const T& value)
 {

--- a/src/datasynctool/utils.cpp
+++ b/src/datasynctool/utils.cpp
@@ -32,9 +32,61 @@ template void printParam<std::string>(std::string, const std::string&);
 void displayJsonAsText(const json& data)
 {
     std::println();
+
     for (const auto& [name, value] : data.items())
     {
-        if (value.is_boolean())
+        if (value.is_array())
+        {
+            std::println("{}:", name);
+            for (const auto& item : value)
+            {
+                if (item.is_object())
+                {
+                    for (const auto& [key, val] : item.items())
+                    {
+                        if (val.is_array())
+                        {
+                            std::println("    {}:", key);
+                            for (const auto& arrItem : val)
+                            {
+                                std::println("        {}",
+                                             arrItem.is_string()
+                                                 ? arrItem.get<std::string>()
+                                                 : arrItem.dump());
+                            }
+                        }
+                        else if (val.is_string())
+                        {
+                            std::println("    {}: {}", key,
+                                         val.get<std::string>());
+                        }
+                        else if (val.is_boolean())
+                        {
+                            std::println("    {}: {}", key, val.get<bool>());
+                        }
+                        else if (val.is_number_integer())
+                        {
+                            std::println("    {}: {}", key, val.get<int>());
+                        }
+                        else
+                        {
+                            std::println("    {}: {}", key, val.dump());
+                        }
+                    }
+                    std::println();
+                }
+                // Handle array of strings
+                else if (item.is_string())
+                {
+                    std::println("  {}", item.get<std::string>());
+                }
+                else
+                {
+                    std::println("  {}", item.dump());
+                }
+            }
+        }
+        else if (value.is_boolean())
         {
             printParam(name, value.get<bool>());
         }

--- a/src/datasynctool/utils.hpp
+++ b/src/datasynctool/utils.hpp
@@ -35,6 +35,12 @@ void printParam(std::string key, const T& value);
 /**
  * @brief Display JSON data in human-readable text format
  *
+ * Handles top-level objects with 1 level of nesting:
+ * - Top-level key-value pairs (simple types)
+ * - Top-level arrays of strings
+ * - Top-level arrays of objects (with nested arrays displayed on separate
+ * lines)
+ *
  * @param[in] data - JSON object to display
  */
 void displayJsonAsText(const json& data);

--- a/src/datasynctool/utils.hpp
+++ b/src/datasynctool/utils.hpp
@@ -24,6 +24,14 @@ using json = nlohmann::ordered_json;
 std::string extractEnumValue(const std::string& dbusValue);
 
 /**
+ * @brief Normalize a path by removing trailing slashes
+ *        Treats /a/b/c and /a/b/c/ as equal
+ *
+ * @param[in] - path : File system path to normalise
+ */
+std::string normalizePath(const std::string& path);
+
+/**
  * @brief Print a parameter in text format based on the given key and value
  *
  * @param[in] key - Parameter name


### PR DESCRIPTION
This PR is on top of the [PR:101](https://github.com/ibm-openbmc/phosphor-data-sync/pull/101). Hence please review the below commits only .
1. [datasynctool : Add --configPaths option](https://github.com/ibm-openbmc/phosphor-data-sync/commit/809a384937d0d7f212a52ab5701ac6599540a90d)
2. [datasynctool : Add --getconf option](https://github.com/ibm-openbmc/phosphor-data-sync/commit/5854b417f7c6221d628d59daebeb06ec1f2dcf67)