### PR TITLE
Datasynctool: Adding options to get sync failure data 

### DIFF
--- a/src/datasynctool/error_summary.cpp
+++ b/src/datasynctool/error_summary.cpp
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "error_summary.hpp"
+
+#include <sys/wait.h>
+
+#include <nlohmann/json.hpp>
+
+#include <array>
+#include <cerrno>
+#include <cstdio>
+#include <format>
+#include <map>
+#include <optional>
+#include <print>
+#include <ranges>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+namespace datasynctool::error_summary
+{
+
+using json = nlohmann::ordered_json;
+
+// ── Constants
+// ─────────────────────────────────────────────────────────────────
+
+constexpr std::string_view datasyncSrcPrefix = "BD8D70";
+
+constexpr std::string_view separator =
+    "─────────────────────────────────────────────────";
+
+// Read buffer for popen output
+constexpr std::size_t readBufSize = 4096;
+
+// Registry message map
+static const std::map<std::string_view, std::string_view> srcRegistryMap = {
+    {"BD8D7001", "SyncFailure"},
+    {"BD8D7002", "SyncEventsFailure"},
+    {"BD8D7003", "ParserFailure"},
+    {"BD8D7004", "NotifyFailure"},
+};
+
+// Field descriptors
+static constexpr PelField fieldRegistryMsg = {"Primary SRC", "Reference Code",
+                                              "Registry Message"};
+
+static constexpr PelField fieldFailureTime = {"Private Header", "Committed at",
+                                              "Failure Time"};
+
+static constexpr PelField fieldPelId = {"Private Header", "Platform Log Id",
+                                        "PEL ID"};
+
+// SyncFailure - only fields
+static constexpr PelField fieldPath = {"User Data 1", "DS_Sync_Path", "Path"};
+static constexpr PelField fieldErrMsg = {"User Data 1", "DS_Sync_ErrMsg",
+                                         "ErrMsg"};
+static constexpr PelField fieldErrCode = {"User Data 1", "DS_Sync_ErrCode",
+                                          "ErrCode"};
+
+static std::optional<std::string> runCommand(std::string_view cmd)
+{
+    // NOLINTNEXTLINE
+    FILE* pipe = popen(std::string(cmd).c_str(), "r");
+    if (pipe == nullptr)
+    {
+        std::println(stderr, "popen failed for command: {}", cmd);
+        return std::nullopt;
+    }
+
+    std::string output;
+    output.reserve(readBufSize);
+    std::array<char, readBufSize> buf{};
+    std::size_t n = 0;
+    while ((n = std::fread(buf.data(), 1, buf.size(), pipe)) > 0)
+    {
+        const auto chunk = std::span(buf).first(n);
+        output.append(chunk.begin(), chunk.end());
+    }
+
+    const int status = pclose(pipe);
+    if (status == -1)
+    {
+        std::println(stderr, "pclose failed: {}",
+                     std::system_category().message(errno));
+    }
+    else if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
+    {
+        std::println(stderr, "peltool.py exited with code {}",
+                     WEXITSTATUS(status));
+    }
+
+    return output;
+}
+
+// Extract a string value from a PEL JSON object using a PelField descriptor.
+// Returns an empty string if the parent section or child key is absent.
+static std::string_view extractField(const json& pelData, const PelField& field)
+{
+    const auto parentIt = pelData.find(field.parent);
+    if (parentIt == pelData.end() || !parentIt->is_object())
+    {
+        return {};
+    }
+    const auto childIt = parentIt->find(field.child);
+    return (childIt != parentIt->end() && childIt->is_string())
+               ? std::string_view(childIt->get_ref<const std::string&>())
+               : std::string_view{};
+}
+
+// Build a SummaryEntry from a single PEL JSON object.
+static SummaryEntry makeSummaryEntry(const json& pelData)
+{
+    const std::string_view rawSrc = extractField(pelData, fieldRegistryMsg);
+    const auto it = srcRegistryMap.find(rawSrc);
+    // Resolve the raw SRC reference code to a registry message string.
+    // Falls back to the raw code if not found in the map.
+    const std::string_view regMsg = it != srcRegistryMap.end() ? it->second
+                                                               : rawSrc;
+
+    SummaryEntry entry{
+        .registryMsg = std::string(regMsg),
+        .failureTime = std::string(extractField(pelData, fieldFailureTime)),
+        .pelId = std::string(extractField(pelData, fieldPelId)),
+        .path = {},
+        .errMsg = {},
+        .errCode = {},
+    };
+
+    if (regMsg == "SyncFailure")
+    {
+        entry.path = std::string(extractField(pelData, fieldPath));
+        entry.errMsg = std::string(extractField(pelData, fieldErrMsg));
+        entry.errCode = std::string(extractField(pelData, fieldErrCode));
+    }
+
+    return entry;
+}
+
+sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput)
+{
+    const auto output = runCommand(
+        std::format("peltool.py --src {} -r 1 -a", datasyncSrcPrefix));
+
+    if (!output.has_value() || output->empty())
+    {
+        std::println("peltool.py returned no output for SRC prefix {}",
+                     datasyncSrcPrefix);
+        co_return;
+    }
+
+    json pelMap;
+    try
+    {
+        pelMap = json::parse(*output);
+    }
+    catch (const json::exception& e)
+    {
+        std::println(stderr, "Failed to parse peltool output: {}", e.what());
+        co_return;
+    }
+
+    if (!pelMap.is_object())
+    {
+        std::println(stderr, "Unexpected peltool output format");
+        co_return;
+    }
+
+    // Collect one SummaryEntry per error log.
+    auto entries = pelMap.items() | std::views::filter([](const auto& kv) {
+        return kv.value().is_object();
+    }) | std::views::transform([](const auto& kv) {
+        return makeSummaryEntry(kv.value());
+    }) | std::views::filter([](const SummaryEntry& e) {
+        return !e.registryMsg.empty() || !e.failureTime.empty() ||
+               !e.pelId.empty();
+    }) | std::ranges::to<std::vector>();
+
+    if (entries.empty())
+    {
+        std::println("No DataSync error logs found");
+        co_return;
+    }
+
+    if (jsonOutput)
+    {
+        auto out = entries | std::views::transform([](const SummaryEntry& e) {
+            json obj;
+            obj[fieldRegistryMsg.displayName] = e.registryMsg;
+            obj[fieldFailureTime.displayName] = e.failureTime;
+            obj[fieldPelId.displayName] = e.pelId;
+            if (!e.path.empty() || !e.errMsg.empty() || !e.errCode.empty())
+            {
+                obj[fieldPath.displayName] = e.path;
+                obj[fieldErrMsg.displayName] = e.errMsg;
+                obj[fieldErrCode.displayName] = e.errCode;
+            }
+            return obj;
+        }) | std::ranges::to<json>();
+        std::println("{}", out.dump(2));
+        co_return;
+    }
+
+    // Text output
+    for (const auto& e : entries)
+    {
+        std::println("{}", separator);
+        std::println("  {:<18}: {}", fieldRegistryMsg.displayName,
+                     e.registryMsg);
+        std::println("  {:<18}: {}", fieldFailureTime.displayName,
+                     e.failureTime);
+        std::println("  {:<18}: {}", fieldPelId.displayName, e.pelId);
+        if (!e.path.empty() || !e.errMsg.empty() || !e.errCode.empty())
+        {
+            std::println("  {:<18}: {}", fieldPath.displayName, e.path);
+            std::println("  {:<18}: {}", fieldErrMsg.displayName, e.errMsg);
+            std::println("  {:<18}: {}", fieldErrCode.displayName, e.errCode);
+        }
+    }
+    std::println("{}", separator);
+}
+
+} // namespace datasynctool::error_summary

--- a/src/datasynctool/error_summary.cpp
+++ b/src/datasynctool/error_summary.cpp
@@ -111,8 +111,39 @@ static std::string_view extractField(const json& pelData, const PelField& field)
                : std::string_view{};
 }
 
+// Extract trace lines from "User Data 2" and "User Data 3" "Data" arrays.
+static std::vector<std::string> extractTraceLines(const json& pelData)
+{
+    std::vector<std::string> lines;
+
+    for (const std::string_view section : {"User Data 2", "User Data 3"})
+    {
+        const auto sectionIt = pelData.find(section);
+        if (sectionIt == pelData.end() || !sectionIt->is_object())
+        {
+            continue;
+        }
+
+        const auto dataIt = sectionIt->find("Data");
+        if (dataIt == sectionIt->end() || !dataIt->is_array())
+        {
+            continue;
+        }
+
+        for (const auto& item : *dataIt)
+        {
+            if (item.is_string())
+            {
+                lines.emplace_back(item.get<std::string>());
+            }
+        }
+    }
+
+    return lines;
+}
+
 // Build a SummaryEntry from a single PEL JSON object.
-static SummaryEntry makeSummaryEntry(const json& pelData)
+static SummaryEntry makeSummaryEntry(const json& pelData, bool includeTrace)
 {
     const std::string_view rawSrc = extractField(pelData, fieldRegistryMsg);
     const auto it = srcRegistryMap.find(rawSrc);
@@ -128,6 +159,7 @@ static SummaryEntry makeSummaryEntry(const json& pelData)
         .path = {},
         .errMsg = {},
         .errCode = {},
+        .traceLines = {},
     };
 
     if (regMsg == "SyncFailure")
@@ -137,11 +169,17 @@ static SummaryEntry makeSummaryEntry(const json& pelData)
         entry.errCode = std::string(extractField(pelData, fieldErrCode));
     }
 
+    if (includeTrace)
+    {
+        entry.traceLines = extractTraceLines(pelData);
+    }
+
     return entry;
 }
 
 sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput,
-                                                std::size_t limit)
+                                                std::size_t limit,
+                                                bool includeTrace)
 {
     const auto output = runCommand(
         std::format("peltool.py --src {} -r {} -a", datasyncSrcPrefix, limit));
@@ -173,8 +211,8 @@ sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput,
     // Collect one SummaryEntry per error log.
     auto entries = pelMap.items() | std::views::filter([](const auto& kv) {
         return kv.value().is_object();
-    }) | std::views::transform([](const auto& kv) {
-        return makeSummaryEntry(kv.value());
+    }) | std::views::transform([includeTrace](const auto& kv) {
+        return makeSummaryEntry(kv.value(), includeTrace);
     }) | std::views::filter([](const SummaryEntry& e) {
         return !e.registryMsg.empty() || !e.failureTime.empty() ||
                !e.pelId.empty();
@@ -199,6 +237,10 @@ sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput,
                 obj[fieldErrMsg.displayName] = e.errMsg;
                 obj[fieldErrCode.displayName] = e.errCode;
             }
+            if (!e.traceLines.empty())
+            {
+                obj["Trace"] = e.traceLines;
+            }
             return obj;
         }) | std::ranges::to<json>();
         std::println("{}", out.dump(2));
@@ -219,6 +261,14 @@ sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput,
             std::println("  {:<18}: {}", fieldPath.displayName, e.path);
             std::println("  {:<18}: {}", fieldErrMsg.displayName, e.errMsg);
             std::println("  {:<18}: {}", fieldErrCode.displayName, e.errCode);
+        }
+        if (!e.traceLines.empty())
+        {
+            std::println("  {:<18}:", "Trace");
+            for (const auto& line : e.traceLines)
+            {
+                std::println("    {}", line);
+            }
         }
     }
     std::println("{}", separator);

--- a/src/datasynctool/error_summary.cpp
+++ b/src/datasynctool/error_summary.cpp
@@ -140,10 +140,11 @@ static SummaryEntry makeSummaryEntry(const json& pelData)
     return entry;
 }
 
-sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput)
+sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput,
+                                                std::size_t limit)
 {
     const auto output = runCommand(
-        std::format("peltool.py --src {} -r 1 -a", datasyncSrcPrefix));
+        std::format("peltool.py --src {} -r {} -a", datasyncSrcPrefix, limit));
 
     if (!output.has_value() || output->empty())
     {

--- a/src/datasynctool/error_summary.hpp
+++ b/src/datasynctool/error_summary.hpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <sdbusplus/async.hpp>
+
+#include <string>
+#include <string_view>
+
+namespace datasynctool::error_summary
+{
+
+/**
+ * @brief Describes a single field to extract from a PEL JSON object.
+ *
+ * The PEL JSON produced by peltool is a two-level map:
+ *   { "<parent>": { "<child>": "<value>" } }
+ *
+ * @var parent       Top-level section key.
+ * @var child        Key inside that section.
+ * @var displayName  Label used in output.
+ */
+struct PelField
+{
+    std::string_view parent;
+    std::string_view child;
+    std::string_view displayName;
+};
+
+/**
+ * @brief The fields collected for every DataSync failure PEL.
+ *
+ * Core fields (all error types):
+ *   - registryMsg  : Primary SRC / Reference Code
+ *   - failureTime  : Private Header / Committed at
+ *   - pelId        : Private Header / Platform Log Id
+ *
+ * In SyncFailure :
+ *   - path         : User Data 1 / DS_Sync_Path
+ *   - errMsg       : User Data 1 / DS_Sync_ErrMsg
+ *   - errCode      : User Data 1 / DS_Sync_ErrCode
+ */
+struct SummaryEntry
+{
+    std::string registryMsg;
+    std::string failureTime;
+    std::string pelId;
+
+    // SyncFailure
+    std::string path;
+    std::string errMsg;
+    std::string errCode;
+};
+
+/**
+ * @brief Print a summary of DataSync error logs.
+ *
+ * Queries peltool for all PELs whose SRC begins with the DataSync prefix
+ * (BD8D70).  For each matching PEL the three fields above are extracted and
+ * displayed either as formatted text or JSON.
+ *
+ * @param[in] jsonOutput  Emit JSON array when true, formatted text otherwise.
+ * @return async task
+ */
+sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput);
+
+} // namespace datasynctool::error_summary

--- a/src/datasynctool/error_summary.hpp
+++ b/src/datasynctool/error_summary.hpp
@@ -58,9 +58,12 @@ struct SummaryEntry
  * (BD8D70).  For each matching PEL the three fields above are extracted and
  * displayed either as formatted text or JSON.
  *
- * @param[in] jsonOutput  Emit JSON array when true, formatted text otherwise.
+ * @param[in] jsonOutput Output in JSON format if true
+ * @param[in] limit      Maximum number of recent logs to display (default: 1)
+ *
  * @return async task
  */
-sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput);
+sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput,
+                                                std::size_t limit = 1);
 
 } // namespace datasynctool::error_summary

--- a/src/datasynctool/error_summary.hpp
+++ b/src/datasynctool/error_summary.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace datasynctool::error_summary
 {
@@ -38,6 +39,9 @@ struct PelField
  *   - path         : User Data 1 / DS_Sync_Path
  *   - errMsg       : User Data 1 / DS_Sync_ErrMsg
  *   - errCode      : User Data 1 / DS_Sync_ErrCode
+ *
+ * When trace is requested:
+ *   - traceLines   : User Data 2 / Data  and  User Data 3 / Data
  */
 struct SummaryEntry
 {
@@ -49,6 +53,9 @@ struct SummaryEntry
     std::string path;
     std::string errMsg;
     std::string errCode;
+
+    // Trace
+    std::vector<std::string> traceLines;
 };
 
 /**
@@ -58,12 +65,14 @@ struct SummaryEntry
  * (BD8D70).  For each matching PEL the three fields above are extracted and
  * displayed either as formatted text or JSON.
  *
- * @param[in] jsonOutput Output in JSON format if true
- * @param[in] limit      Maximum number of recent logs to display (default: 1)
+ * @param[in] jsonOutput    Output in JSON format if true
+ * @param[in] limit         Maximum number of logs to display (default: 1)
+ * @param[in] includeTrace  Include datasync trace lines in each entry if true
  *
  * @return async task
  */
 sdbusplus::async::task<> displayErrorLogSummary(bool jsonOutput,
-                                                std::size_t limit = 1);
+                                                std::size_t limit = 1,
+                                                bool includeTrace = false);
 
 } // namespace datasynctool::error_summary

--- a/src/datasynctool/main.cpp
+++ b/src/datasynctool/main.cpp
@@ -46,10 +46,16 @@ int main(int argc, char* argv[])
         "DataSync Error Log",
         "Retrieve and display DataSync component error log summary");
 
-    bool showErrorLog{false};
-    errorGroup->add_flag(
-        "-S,--syncFailure", showErrorLog,
-        "Display a summary of recent DataSync sync failure logs");
+    std::size_t errorLogCount{0};
+    auto* errorLogOpt =
+        errorGroup
+            ->add_option(
+                "-S,--syncFailure", errorLogCount,
+                "Display a summary of recent DataSync sync failure logs.\n"
+                "Pass N to limit output to the N most recent logs.")
+            ->type_name("N")
+            ->expected(0, 1)
+            ->default_val(1);
 
     auto* configGroup = app.add_option_group("Config options",
                                              "Configuration related options");
@@ -85,10 +91,10 @@ int main(int argc, char* argv[])
 
     sdbusplus::async::context ctx;
 
-    if (showErrorLog)
+    if (errorLogOpt->count() != 0U)
     {
-        ctx.spawn(
-            datasynctool::error_summary::displayErrorLogSummary(jsonOutput));
+        ctx.spawn(datasynctool::error_summary::displayErrorLogSummary(
+            jsonOutput, errorLogCount));
     }
 
     if (enableSync)

--- a/src/datasynctool/main.cpp
+++ b/src/datasynctool/main.cpp
@@ -57,6 +57,13 @@ int main(int argc, char* argv[])
             ->expected(0, 1)
             ->default_val(1);
 
+    bool includeTrace{false};
+    auto* traceOpt = errorGroup->add_flag(
+        "-T,--trace", includeTrace,
+        "Include datasync trace lines in each sync failure log entry.\n"
+        "Only valid with -S/--syncFailure.");
+    traceOpt->needs(errorLogOpt);
+
     auto* configGroup = app.add_option_group("Config options",
                                              "Configuration related options");
 
@@ -94,7 +101,7 @@ int main(int argc, char* argv[])
     if (errorLogOpt->count() != 0U)
     {
         ctx.spawn(datasynctool::error_summary::displayErrorLogSummary(
-            jsonOutput, errorLogCount));
+            jsonOutput, errorLogCount, includeTrace));
     }
 
     if (enableSync)

--- a/src/datasynctool/main.cpp
+++ b/src/datasynctool/main.cpp
@@ -2,6 +2,7 @@
 
 #include "config_options.hpp"
 #include "dbus_interactions.hpp"
+#include "error_summary.hpp"
 
 #include <CLI/CLI.hpp>
 #include <sdbusplus/async.hpp>
@@ -41,6 +42,15 @@ int main(int argc, char* argv[])
 
     enableOpt->excludes(disableOpt);
 
+    auto* errorGroup = app.add_option_group(
+        "DataSync Error Log",
+        "Retrieve and display DataSync component error log summary");
+
+    bool showErrorLog{false};
+    errorGroup->add_flag(
+        "-S,--syncFailure", showErrorLog,
+        "Display a summary of recent DataSync sync failure logs");
+
     auto* configGroup = app.add_option_group("Config options",
                                              "Configuration related options");
 
@@ -74,6 +84,12 @@ int main(int argc, char* argv[])
     CLI11_PARSE(app, argc, argv);
 
     sdbusplus::async::context ctx;
+
+    if (showErrorLog)
+    {
+        ctx.spawn(
+            datasynctool::error_summary::displayErrorLogSummary(jsonOutput));
+    }
 
     if (enableSync)
     {

--- a/src/datasynctool/meson.build
+++ b/src/datasynctool/meson.build
@@ -8,6 +8,7 @@ cli11_dep = dependency('CLI11')
 datasynctool_sources = files(
     'config_options.cpp',
     'dbus_interactions.cpp',
+    'error_summary.cpp',
     'main.cpp',
     'utils.cpp',
 )


### PR DESCRIPTION
- Added a new option `--error-logs` or `-E` to get the summary of all pels under `bmc datasync` component.
