### PR TITLE
systemd: Order data-sync after BIOS attr update

### DIFF
--- a/service_files/xyz.openbmc_project.Control.SyncBMCData.service
+++ b/service_files/xyz.openbmc_project.Control.SyncBMCData.service
@@ -2,6 +2,9 @@
 Description=Redundant BMC Data Synchronization
 Wants=xyz.openbmc_project.State.BMC.Redundancy.service
 After=xyz.openbmc_project.State.BMC.Redundancy.service
+# TODO: Move this OpenPOWER-specific ordering when
+# data-sync is upstreamed.
+After=openpower-update-bios-attr-table.service
 
 [Service]
 ExecStart=/usr/libexec/phosphor-data-sync/phosphor-rbmc-data-sync-mgr


### PR DESCRIPTION
The BIOS attr update service prepares files under the host firmware running directory. Data-sync watches and synchronizes configured paths from the same area during startup.

Order the redundant BMC data-sync service after the BIOS attr update service so data-sync starts after those paths have been prepared. This avoids data-sync starting before those paths are created during boot.

This keeps the boot ordering explicit between the service that prepares these paths and the service that consumes them.
