### PR TITLE
config: Don't sync the RBMC wait status file

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -22,7 +22,8 @@
                 "/var/lib/phosphor-state-manager/requestedHostTransition",
                 "/var/lib/phosphor-state-manager/POHCounter",
                 "/var/lib/phosphor-state-manager/chassisStateChangeTime",
-                "/var/lib/phosphor-state-manager/redundant-bmc/data.json"
+                "/var/lib/phosphor-state-manager/redundant-bmc/data.json",
+                "/var/lib/phosphor-state-manager/redundant-bmc/wait_status.json"
             ]
         },
         {


### PR DESCRIPTION
This file is specific to the BMC it was created on.