### PR TITLE
manager: avoid duplicate bidirectional watchers on sync enable

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -264,9 +264,21 @@ sdbusplus::async::task<> Manager::startSyncEvents()
         return this->isSyncEligible(dataSyncCfg);
     }),
         [this](const auto& dataSyncCfg) {
+        using enum config::SyncDirection;
         using enum config::SyncType;
         if (dataSyncCfg._syncType == Immediate)
         {
+            // Bidirectional watchers can already be running when sync is
+            // enabled again during failover. Skip creating the same watcher
+            // again.
+            if ((dataSyncCfg._syncDirection == Bidirectional) &&
+                _activeWatchers.contains(dataSyncCfg._path))
+            {
+                lg2::debug(
+                    "Bidirectional watcher already exists for {PATH}, skipping duplicate watcher",
+                    "PATH", dataSyncCfg._path);
+                return;
+            }
             try
             {
                 this->_ctx.spawn(this->monitorDataToSync(dataSyncCfg));


### PR DESCRIPTION
During failover, the RBMC state manager disables background sync and then enables it again before starting a full sync. Data sync currently does not cancel active inotify watchers when sync is disabled.

For bidirectional immediate sync configs, the existing watcher is still valid before and after the role change. When sync is enabled again, data sync can try to start another watcher for the same path that can result in two awaits on the same fdio object and crash with:
```
 what():fdio_completion started with another await already pending!
```
Skip starting a bidirectional immediate watcher when a watcher for the same configured path is already active. This avoids the duplicate watcher during failover while still allowing fresh startup to create the watcher normally.