### PR TITLE
Add deferred sync support

### DIFF
--- a/config/schema/example.json
+++ b/config/schema/example.json
@@ -55,6 +55,13 @@
                 "Mode": "DBus",
                 "NotifyServices": ["Service1", "Service2"]
             }
+        },
+        {
+            "Path": "/directory3/path/to/sync/",
+            "Description": "Add details about the data and purpose of the synchronization",
+            "SyncDirection": "Bidirectional",
+            "SyncType": "Deferred",
+            "DeferredSyncInterval": "PT1S"
         }
     ]
 }

--- a/config/schema/schema.json
+++ b/config/schema/schema.json
@@ -56,6 +56,9 @@
                 "Periodicity": {
                     "$ref": "#/$defs/periodicity"
                 },
+                "DeferredSyncInterval": {
+                    "$ref": "#/$defs/deferredSyncInterval"
+                },
                 "NotifySibling": {
                     "$ref": "#/$defs/notifySiblingForFiles"
                 },
@@ -70,6 +73,7 @@
             "additionalProperties": false,
             "allOf": [
                 { "$ref": "#/$defs/conditionForPeriodicity" },
+                { "$ref": "#/$defs/conditionForDeferredSyncInterval" },
                 { "$ref": "#/$defs/conditionForRetry" }
             ]
         },
@@ -95,6 +99,9 @@
                 "Periodicity": {
                     "$ref": "#/$defs/periodicity"
                 },
+                "DeferredSyncInterval": {
+                    "$ref": "#/$defs/deferredSyncInterval"
+                },
                 "NotifySibling": {
                     "$ref": "#/$defs/notifySiblingForDirs"
                 },
@@ -119,6 +126,7 @@
             "additionalProperties": false,
             "allOf": [
                 { "$ref": "#/$defs/conditionForPeriodicity" },
+                { "$ref": "#/$defs/conditionForDeferredSyncInterval" },
                 { "$ref": "#/$defs/conditionForRetry" }
             ]
         },
@@ -148,7 +156,7 @@
         },
         "syncType": {
             "description": "The type of sync to be performed",
-            "enum": ["Periodic", "Immediate"]
+            "enum": ["Periodic", "Immediate", "Deferred"]
         },
         "notifySiblingForFiles": {
             "description": "The JSON object which definess how the data owner on the synced side to be notified once the data got changed",
@@ -227,6 +235,11 @@
             "type": "string",
             "format": "duration"
         },
+        "deferredSyncInterval": {
+            "description": "The quiet interval in ISO 8601 duration format before a deferred sync operation. Eg: PT1S - 1 second",
+            "type": "string",
+            "format": "duration"
+        },
         "excludeList": {
             "description": "The list of paths in the directory that should be excluded while sync operation",
             "type": "array",
@@ -294,6 +307,22 @@
                 "required": ["Periodicity"]
             },
             "else": { "not": { "required": ["Periodicity"] } }
+        },
+        "conditionForDeferredSyncInterval": {
+            "if": {
+                "type": "object",
+                "properties": { "SyncType": { "const": "Deferred" } },
+                "required": ["SyncType"]
+            },
+            "then": {
+                "properties": {
+                    "DeferredSyncInterval": {
+                        "$ref": "#/$defs/deferredSyncInterval"
+                    }
+                },
+                "required": ["DeferredSyncInterval"]
+            },
+            "else": { "not": { "required": ["DeferredSyncInterval"] } }
         },
         "conditionForRetry": {
             "if": {

--- a/src/data_sync_config.cpp
+++ b/src/data_sync_config.cpp
@@ -75,6 +75,19 @@ DataSyncConfig::DataSyncConfig(const nlohmann::json& config,
         _periodicityInSec = std::nullopt;
     }
 
+    if (_syncType == SyncType::Deferred)
+    {
+        constexpr auto defDeferredSyncInterval = 1;
+        _deferredSyncIntervalInSec =
+            convertISODurationToSec(
+                config["DeferredSyncInterval"].get<std::string>())
+                .value_or(std::chrono::seconds(defDeferredSyncInterval));
+    }
+    else
+    {
+        _deferredSyncIntervalInSec = std::nullopt;
+    }
+
     if (config.contains("NotifySibling"))
     {
         _notifySibling = NotifySiblingConfig(config["NotifySibling"]);
@@ -123,6 +136,8 @@ bool DataSyncConfig::operator==(const DataSyncConfig& dataSyncCfg) const
            _destPath == dataSyncCfg._destPath &&
            _syncType == dataSyncCfg._syncType &&
            _periodicityInSec == dataSyncCfg._periodicityInSec &&
+           _deferredSyncIntervalInSec ==
+               dataSyncCfg._deferredSyncIntervalInSec &&
            _retry == dataSyncCfg._retry &&
            _excludeList == dataSyncCfg._excludeList &&
            _includeList == dataSyncCfg._includeList;
@@ -172,6 +187,10 @@ std::optional<SyncType>
     if (syncType == "Immediate")
     {
         return SyncType::Immediate;
+    }
+    else if (syncType == "Deferred")
+    {
+        return SyncType::Deferred;
     }
     else if (syncType == "Periodic")
     {

--- a/src/data_sync_config.hpp
+++ b/src/data_sync_config.hpp
@@ -32,6 +32,7 @@ enum class SyncDirection
 enum class SyncType
 {
     Immediate,
+    Deferred,
     Periodic
 };
 
@@ -168,6 +169,8 @@ struct DataSyncConfig
         {
             case SyncType::Immediate:
                 return "Immediate";
+            case SyncType::Deferred:
+                return "Deferred";
             case SyncType::Periodic:
                 return "Periodic";
         }
@@ -205,6 +208,13 @@ struct DataSyncConfig
      * @note Holds a value if the synchronization type is set to Periodic.
      */
     std::optional<std::chrono::seconds> _periodicityInSec;
+
+    /**
+     * @brief Delay before running a deferred sync.
+     *
+     * @note Holds a value if the synchronization type is set to Deferred.
+     */
+    std::optional<std::chrono::seconds> _deferredSyncIntervalInSec;
 
     /**
      * @brief The details of sibling notification

--- a/src/data_sync_config.hpp
+++ b/src/data_sync_config.hpp
@@ -263,6 +263,16 @@ struct DataSyncConfig
      */
     mutable std::unordered_set<fs::path> _syncInProgressPaths;
 
+    /**
+     * @brief Tracks whether deferred sync is already scheduled.
+     */
+    mutable bool _deferredSyncScheduled = false;
+
+    /**
+     * @brief Timestamp of the latest event received for deferred sync.
+     */
+    mutable std::chrono::steady_clock::time_point _lastDeferredSyncEventTime;
+
   private:
     /**
      * @brief A helper API to retrieve the corresponding enum type

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -291,6 +291,28 @@ sdbusplus::async::task<> Manager::startSyncEvents()
                 setSyncEventsHealth(SyncEventsHealth::Critical);
             }
         }
+        else if (dataSyncCfg._syncType == Deferred)
+        {
+            if ((dataSyncCfg._syncDirection == Bidirectional) &&
+                _activeWatchers.contains(dataSyncCfg._path))
+            {
+                lg2::debug(
+                    "Bidirectional watcher already exists for {PATH}, skipping duplicate watcher",
+                    "PATH", dataSyncCfg._path);
+                return;
+            }
+            try
+            {
+                this->_ctx.spawn(this->monitorDeferredDataToSync(dataSyncCfg));
+            }
+            catch (const std::exception& e)
+            {
+                lg2::error(
+                    "Failed to start deferred sync for {PATH}: {EXCEPTION}",
+                    "EXCEPTION", e, "PATH", dataSyncCfg._path);
+                setSyncEventsHealth(SyncEventsHealth::Critical);
+            }
+        }
         else if (dataSyncCfg._syncType == Periodic)
         {
             try
@@ -811,6 +833,113 @@ sdbusplus::async::task<>
             {"DS_Events_Path", dataSyncCfg._path.string()},
             {"DS_Events_Msg",
              "Exception: Failed to create inotify watcher for the configured path"}};
+        co_await _extDataIfaces->createErrorLog(
+            "xyz.openbmc_project.RBMC_DataSync.Error.SyncEventsFailure",
+            ext_data::ErrorLevel::Warning, additionalDetails);
+    }
+    co_return;
+}
+
+void Manager::deferSync(const config::DataSyncConfig& dataSyncCfg)
+{
+    dataSyncCfg._lastDeferredSyncEventTime = std::chrono::steady_clock::now();
+
+    if (dataSyncCfg._deferredSyncScheduled)
+    {
+        return;
+    }
+
+    dataSyncCfg._deferredSyncScheduled = true;
+    _ctx.spawn(syncDeferredData(dataSyncCfg));
+}
+
+sdbusplus::async::task<>
+    Manager::syncDeferredData(const config::DataSyncConfig& dataSyncCfg)
+{
+    while (!_ctx.stop_requested() && !_syncBMCDataIface.disable_sync() &&
+           dataSyncCfg._deferredSyncIntervalInSec.has_value())
+    {
+        const auto deferredSyncInterval =
+            dataSyncCfg._deferredSyncIntervalInSec.value();
+
+        // Time since the most recent event. If another event arrives before the
+        // interval completes, the timestamp is updated and this loop waits
+        // again from that new event time.
+        const auto timeSinceLastEvent = std::chrono::steady_clock::now() -
+                                        dataSyncCfg._lastDeferredSyncEventTime;
+
+        if (timeSinceLastEvent < deferredSyncInterval)
+        {
+            // Wait only for the remaining interval. Example: for a 1s interval,
+            // if the last event was 300ms ago, wait 700ms more.
+            co_await sleep_for(_ctx, deferredSyncInterval - timeSinceLastEvent);
+            continue;
+        }
+
+        // Remember the event timestamp covered by this sync. If another event
+        // arrives while rsync is running, the timestamp changes and we run
+        // another sync.
+        const auto syncedEventTime = dataSyncCfg._lastDeferredSyncEventTime;
+
+        lg2::debug(
+            "Deferred sync quiet interval elapsed for [{PATH}], triggering root sync",
+            "PATH", dataSyncCfg._path);
+
+        // NOLINTNEXTLINE
+        co_await syncData(dataSyncCfg);
+
+        if (dataSyncCfg._lastDeferredSyncEventTime == syncedEventTime)
+        {
+            // No new event arrived during rsync, so deferred sync is complete.
+            break;
+        }
+    }
+
+    dataSyncCfg._deferredSyncScheduled = false;
+    co_return;
+}
+
+sdbusplus::async::task<>
+    // NOLINTNEXTLINE
+    Manager::monitorDeferredDataToSync(
+        const config::DataSyncConfig& dataSyncCfg)
+{
+    bool exception{false};
+    try
+    {
+        auto* dataWatcher = addDataWatcher(dataSyncCfg);
+
+        // Ensure removal on scope exit
+        auto cleanup = std::experimental::scope_exit([this, &dataSyncCfg]() {
+            _activeWatchers.erase(dataSyncCfg._path);
+        });
+
+        while (!_ctx.stop_requested() && !_syncBMCDataIface.disable_sync())
+        {
+            // NOLINTNEXTLINE
+            if (auto dataOperations = co_await dataWatcher->onDataChange();
+                !dataOperations.empty())
+            {
+                lg2::debug(
+                    "Deferring sync for [{PATH}], received [{COUNT}] data operations",
+                    "PATH", dataSyncCfg._path, "COUNT", dataOperations.size());
+                deferSync(dataSyncCfg);
+            }
+        }
+    }
+    catch (std::exception& e)
+    {
+        lg2::error("Failed to create deferred watcher object for {PATH}. "
+                   "Exception : {ERROR}",
+                   "PATH", dataSyncCfg._path, "ERROR", e.what());
+        exception = true;
+    }
+    if (exception)
+    {
+        ext_data::AdditionalData additionalDetails = {
+            {"DS_Events_Path", dataSyncCfg._path.string()},
+            {"DS_Events_Msg",
+             "Exception: Failed to create deferred inotify watcher for the configured path"}};
         co_await _extDataIfaces->createErrorLog(
             "xyz.openbmc_project.RBMC_DataSync.Error.SyncEventsFailure",
             ext_data::ErrorLevel::Warning, additionalDetails);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -745,6 +745,29 @@ sdbusplus::async::task<>
     co_return;
 }
 
+watch::inotify::DataWatcher*
+    Manager::addDataWatcher(const config::DataSyncConfig& dataSyncCfg)
+{
+    uint32_t eventMasksToWatch = IN_CLOSE_WRITE | IN_MOVE | IN_DELETE_SELF;
+    if (dataSyncCfg._isPathDir)
+    {
+        eventMasksToWatch |= IN_CREATE | IN_DELETE;
+    }
+
+    auto excludeList = dataSyncCfg._excludeList.has_value()
+                           ? std::make_optional<std::unordered_set<fs::path>>(
+                                 dataSyncCfg._excludeList.value().first)
+                           : std::nullopt;
+
+    auto [it, _] = _activeWatchers.emplace(
+        dataSyncCfg._path,
+        std::make_unique<watch::inotify::DataWatcher>(
+            _ctx, IN_NONBLOCK | IN_CLOEXEC, eventMasksToWatch,
+            dataSyncCfg._path, excludeList, dataSyncCfg._includeList));
+
+    return it->second.get();
+}
+
 sdbusplus::async::task<>
     // NOLINTNEXTLINE
     Manager::monitorDataToSync(const config::DataSyncConfig& dataSyncCfg)
@@ -752,25 +775,7 @@ sdbusplus::async::task<>
     bool exception{false};
     try
     {
-        uint32_t eventMasksToWatch = IN_CLOSE_WRITE | IN_MOVE | IN_DELETE_SELF;
-        if (dataSyncCfg._isPathDir)
-        {
-            eventMasksToWatch |= IN_CREATE | IN_DELETE;
-        }
-
-        auto excludeList =
-            dataSyncCfg._excludeList.has_value()
-                ? std::make_optional<std::unordered_set<fs::path>>(
-                      dataSyncCfg._excludeList.value().first)
-                : std::nullopt;
-
-        auto [it, inserted] = _activeWatchers.emplace(
-            dataSyncCfg._path,
-            std::make_unique<watch::inotify::DataWatcher>(
-                _ctx, IN_NONBLOCK | IN_CLOEXEC, eventMasksToWatch,
-                dataSyncCfg._path, excludeList, dataSyncCfg._includeList));
-
-        auto* dataWatcher = it->second.get();
+        auto* dataWatcher = addDataWatcher(dataSyncCfg);
 
         // Ensure removal on scope exit
         auto cleanup = std::experimental::scope_exit([this, &dataSyncCfg]() {

--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -270,6 +270,16 @@ class Manager
         monitorDataToSync(const config::DataSyncConfig& dataSyncCfg);
 
     /**
+     * @brief Create and register a DataWatcher for the given sync config.
+     *
+     * @param[in] dataSyncCfg - The data sync config to watch
+     *
+     * @return Pointer to the registered watcher
+     */
+    watch::inotify::DataWatcher*
+        addDataWatcher(const config::DataSyncConfig& dataSyncCfg);
+
+    /**
      * @brief A helper to API to sync data periodically.
      *
      * @param[in] dataSyncCfg - The data sync config to sync

--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -280,6 +280,29 @@ class Manager
         addDataWatcher(const config::DataSyncConfig& dataSyncCfg);
 
     /**
+     * @brief A helper API to monitor data changes and trigger deferred sync.
+     *
+     * @param[in] dataSyncCfg - The data sync config to sync
+     */
+    sdbusplus::async::task<>
+        monitorDeferredDataToSync(const config::DataSyncConfig& dataSyncCfg);
+
+    /**
+     * @brief Schedule a deferred sync for the changed data.
+     *
+     * @param[in] dataSyncCfg - The data sync config to sync
+     */
+    void deferSync(const config::DataSyncConfig& dataSyncCfg);
+
+    /**
+     * @brief Wait for the deferred interval and run sync.
+     *
+     * @param[in] dataSyncCfg - The data sync config to sync
+     */
+    sdbusplus::async::task<>
+        syncDeferredData(const config::DataSyncConfig& dataSyncCfg);
+
+    /**
      * @brief A helper to API to sync data periodically.
      *
      * @param[in] dataSyncCfg - The data sync config to sync

--- a/test/data_sync_config_test.cpp
+++ b/test/data_sync_config_test.cpp
@@ -96,6 +96,47 @@ TEST(DataSyncConfigParserTest, TestPeriodicFileSyncWithRetry)
 
 /*
  * Test when the input JSON contains the details of the directory to be synced
+ * after a deferred interval with no overriding retry attempt and retry
+ * interval.
+ */
+TEST(DataSyncConfigParserTest, TestDeferredDirectorySyncWithNoRetry)
+{
+    const auto configJSON = R"(
+        {
+            "Path": "/directory/path/to/sync/",
+            "Description": "Add details about the data and purpose of the synchronization",
+            "SyncDirection": "Active2Passive",
+            "SyncType": "Deferred",
+            "DeferredSyncInterval": "PT1S"
+        }
+    )"_json;
+
+    data_sync::config::DataSyncConfig dataSyncConfig(configJSON, true);
+
+    EXPECT_EQ(dataSyncConfig._path, "/directory/path/to/sync/");
+    EXPECT_EQ(dataSyncConfig._isPathDir, true);
+    EXPECT_EQ(dataSyncConfig._destPath, std::nullopt);
+    EXPECT_EQ(dataSyncConfig._syncDirection,
+              data_sync::config::SyncDirection::Active2Passive);
+    EXPECT_EQ(dataSyncConfig._syncType, data_sync::config::SyncType::Deferred);
+    EXPECT_EQ(dataSyncConfig._periodicityInSec, std::nullopt);
+    EXPECT_EQ(dataSyncConfig._deferredSyncIntervalInSec,
+              std::chrono::seconds(1));
+    EXPECT_EQ(dataSyncConfig._notifySibling, std::nullopt);
+    if (!dataSyncConfig._retry.has_value())
+    {
+        FAIL() << "Missing retry configuration.";
+    }
+    EXPECT_EQ(dataSyncConfig._retry.value()._maxRetryAttempts,
+              DEFAULT_RETRY_ATTEMPTS);
+    EXPECT_EQ(dataSyncConfig._retry.value()._retryIntervalInSec,
+              std::chrono::seconds(DEFAULT_RETRY_INTERVAL));
+    EXPECT_EQ(dataSyncConfig._excludeList, std::nullopt);
+    EXPECT_EQ(dataSyncConfig._includeList, std::nullopt);
+}
+
+/*
+ * Test when the input JSON contains the details of the directory to be synced
  * immediately with no overriding retry attempt and retry interval.
  */
 TEST(DataSyncConfigParserTest, TestImmediateDirectorySyncWithNoRetry)


### PR DESCRIPTION
This PR adds Deferred sync support.

In Deferred sync, data-sync waits for a short configured delay after a file change, then runs one sync for the configured path. This helps reduce the number of rsync commands during bulk file changes.