### PR TITLE
config: defer phosphor logging sync

### DIFF
--- a/config/data_sync_list/common.json
+++ b/config/data_sync_list/common.json
@@ -82,7 +82,8 @@
             "Path": "/var/lib/phosphor-logging/",
             "Description": "Phosphor logging persisted data",
             "SyncDirection": "Bidirectional",
-            "SyncType": "Immediate",
+            "SyncType": "Deferred",
+            "DeferredSyncInterval": "PT1S",
             "ExcludeList": ["/var/lib/phosphor-logging/extensions/pels/pelID"]
         }
     ]


### PR DESCRIPTION
Change phosphor logging from Immediate sync to Deferred sync 

This PR will be go after the https://github.com/ibm-openbmc/phosphor-data-sync/pull/111