### PR TITLE
rsync flag : Use --update for bidirectional only

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -359,15 +359,23 @@ void Manager::getRsyncCmd(RsyncMode mode,
                           const std::string& srcPath, std::string& cmd)
 {
     using namespace std::string_literals;
+    using enum config::SyncDirection;
 
+    // Appending required flags to sync data between BMCs
+    // For more details about CLI options, refer rsync man page.
+    // https://download.samba.org/pub/rsync/rsync.1#OPTION_SUMMARY
     cmd.append("rsync --compress --recursive --perms --group --owner --times "
-               "--atimes --update"s);
+               "--atimes"s);
     if (mode == RsyncMode::Sync)
     {
-        // Appending required flags to sync data between BMCs
-        // For more details about CLI options, refer rsync man page.
-        // https://download.samba.org/pub/rsync/rsync.1#OPTION_SUMMARY
-
+        if (dataSyncCfg._syncDirection == Bidirectional)
+        {
+            // skips the operation if dest is newer.
+            // Required for bidirectional as either side can trigger sync like
+            // on full sync In unidirectional sync, sender is the source of
+            // truth.
+            cmd.append(" --update"s);
+        }
         cmd.append(" --relative --delete --delete-missing-args --stats"s);
 
         if (dataSyncCfg._excludeList.has_value())


### PR DESCRIPTION
This commit brings the changes to use `--update` flag only when syncing paths configured for bidirectional sync.

During bidirectional sync, data can be modified on either BMC.  Using `--update` will ensure newer data is not overwritten and copies the source only when it has a newer modification time.

For unidirectional sync(A2P and P2A) sender side data should consider as source of truth irrespective of the modification time of the destination data. This will ensure that after BMC CM, the running BMC data is pushed successfully to the replaced BMC even if the replaced BMC's data has a newer modification time.

Tested:

Verified in hardware that `--update` flag present only for bidirectional paths and is not present during unidirectional paths sync.

Bidirectional sync - Example : PEls
```
Rsync command: rsync --compress --recursive --perms --group --owner
--times --atimes --update --relative --delete --delete-missing-args
--stats --filter='-/ /var/lib/phosphor-logging/extensions/pels/pelID'
/var/lib/phosphor-logging/ <DEST>
```

Active2Passive Sync -  Example - Console logs:
```
Rsync command: rsync --compress --recursive --perms --group --owner
--times --atimes --relative --delete --delete-missing-args --stats
/var/log/obmc-console1.bmc1.log /var/log/obmc-console.bmc1.log
/var/log/obmc-console1.bmc0.log /var/log/obmc-console.bmc0.log <DEST>
```

Change-Id: Ie00d3b54335ce54f357d1f617d3dadcdf2de71ac